### PR TITLE
Update -mtl_addWeakObserver: to allow a selector that doesn't take any arguments

### DIFF
--- a/Mantle/NSNotificationCenter+MTLWeakReferenceAdditions.m
+++ b/Mantle/NSNotificationCenter+MTLWeakReferenceAdditions.m
@@ -45,7 +45,11 @@
 		NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:[observerObject methodSignatureForSelector:selector]];
 		invocation.target = observerObject;
 		invocation.selector = selector;
-		[invocation setArgument:&notification atIndex:2];
+		// It doesn't make sense to invoke methods with more than a single argument.
+		NSCAssert(invocation.methodSignature.numberOfArguments <= 3, @"%s supports selectors with 1 or 0, %ld provided", __func__, (invocation.methodSignature.numberOfArguments - 2));
+		if (invocation.methodSignature.numberOfArguments == 3) {
+			[invocation setArgument:&notification atIndex:2];
+		}
 		[invocation invoke];
 	}];
 

--- a/MantleTests/MTLNotificationCenterAdditionsSpec.m
+++ b/MantleTests/MTLNotificationCenterAdditionsSpec.m
@@ -30,6 +30,25 @@ it(@"should send notifications to weak observers", ^{
 	[NSNotificationCenter.defaultCenter postNotificationName:notificationName object:self];
 });
 
+it(@"should support sending notifications to selectors with no arguments", ^{
+	MTLTestNotificationObserver *observer = [[MTLTestNotificationObserver alloc] init];
+	expect(observer).notTo.beNil();
+
+	id token = [NSNotificationCenter.defaultCenter mtl_addWeakObserver:observer selector:@selector(notificationPosted) name:notificationName object:self];
+	expect(token).notTo.beNil();
+
+	expect(observer.receivedNotification).to.beFalsy();
+	[NSNotificationCenter.defaultCenter postNotificationName:notificationName object:self];
+	expect(observer.receivedNotification).to.beTruthy();
+
+	[NSNotificationCenter.defaultCenter removeObserver:token];
+
+	// The observer shouldn't receive this notification. (It'll throw an
+	// assertion if it does.)
+	[NSNotificationCenter.defaultCenter postNotificationName:notificationName object:self];
+});
+
+
 it(@"should unregister from notifications if the observer is deallocated", ^{
 	__weak id weakObserver = nil;
 

--- a/MantleTests/MTLTestNotificationObserver.m
+++ b/MantleTests/MTLTestNotificationObserver.m
@@ -21,4 +21,9 @@
 	self.receivedNotification = YES;
 }
 
+- (void)notificationPosted {
+	NSAssert(!self.receivedNotification, @"Should receive a single notification");
+	self.receivedNotification = YES;
+}
+
 @end


### PR DESCRIPTION
This is more consistent with `-addObserver:` behaviour and allows us to
ignore the notification if we don't care about it.

Includes a test.
