### PR TITLE
Adds CocoaPods support.

### DIFF
--- a/Mantle.podspec
+++ b/Mantle.podspec
@@ -1,0 +1,18 @@
+Pod::Spec.new do |s|
+  s.name         = "Mantle"
+  s.version      = "0.2"
+  s.summary      = "Model framework for Cocoa and Cocoa Touch."
+
+  s.homepage     = "https://github.com/github/Mantle"
+  s.license      = 'MIT'
+  s.author       = { "GitHub" => "support@github.com" }
+
+  s.source       = { :git => "https://github.com/github/Mantle.git", :tag => "0.2" }
+  s.source_files = 'Mantle'
+  s.framework    = 'Foundation'
+
+  s.ios.deployment_target = '5.0' # there are usages of __weak
+  s.requires_arc = true
+
+  s.dependency 'libextobjc', '~> 0.2'
+end


### PR DESCRIPTION
If you don't already know, checkout [CocoaPods](http://cocoapods.org)

---

Tested that the pod installs and builds fine on lastest OS X and
Xcode version.

A Mantle.podspec has already been pushed to the specs repository:
https://github.com/CocoaPods/Specs/blob/master/Mantle/0.2/Mantle.podspec

This file is added to the repository so you can update the CocoaPods
version by updating the Mantle.podspec file and doing a
`pod push master` (provided that you have push access, which you totally
should)
