### PR TITLE
Mantel should only include utilized subspecs of libextobjc

### DIFF
--- a/Mantle.podspec
+++ b/Mantle.podspec
@@ -12,7 +12,16 @@ Pod::Spec.new do |s|
   s.framework    = 'Foundation'
 
   s.ios.deployment_target = '5.0' # there are usages of __weak
+  s.osx.deployment_target = '10.7'
   s.requires_arc = true
 
-  s.dependency 'libextobjc', '~> 0.2'
+  libextobjc_subspecs = %w[
+    EXTScope
+    EXTKeyPathCoding ]
+
+  libextobj_subspecs.each do |subspec|
+    s.dependency "libextobjc/#{subspec}", '~> 0.2'
+  end
+
 end
+


### PR DESCRIPTION
[Libextobjc](https://github.com/jspahrsummers/libextobjc/tree/master/extobjc) has a ton of features, but at the moment only two are used by Mantel. Luckily they are broken down into subspecs. This commit includes only those needed specs.

Also, following in the vein of requiring 5.0+ for iOS because of the use of __weak, I've included 10.7 as a deployment target as well.

I've submitted this as a pull on [CocoaPods/Specs](https://github.com/CocoaPods/Specs/pull/659) as well.
