### PR TITLE
Fix incorrect transformer code in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,8 +233,8 @@ typedef enum : NSUInteger {
 
     return [MTLValueTransformer reversibleTransformerWithForwardBlock:^(NSString *str) {
         return states[str];
-    } reverseBlock:^(GHIssueState state) {
-        return [states allKeysForObject:@(state)].lastObject;
+    } reverseBlock:^(NSNumber *state) {
+        return [states allKeysForObject:state].lastObject;
     }];
 }
 


### PR DESCRIPTION
MTLValueTransformer can't return primitives, and doesn't need to.
#37
