### PR TITLE
Corrected method name (+supportsSecureCoding)

### DIFF
--- a/Mantle/MTLModel+NSCoding.m
+++ b/Mantle/MTLModel+NSCoding.m
@@ -237,7 +237,7 @@ static void verifyAllowedClassesByPropertyKey(Class modelClass) {
 
 #pragma mark NSSecureCoding
 
-+ (BOOL)allowsSecureCoding {
++ (BOOL)supportsSecureCoding {
 	// Disable secure coding support by default, so subclasses are forced to
 	// opt-in by conforming to the protocol and overriding this method.
 	//


### PR DESCRIPTION
Weirdly enough, this actually prevented secure coding from working _at all_ even though I was overriding +supportsSecureCoding in my own subclasses. +usesSecureCoding must be a private method of some sort.
