### PR TITLE
Fixing Duplicate interface definition errors when using via cocoapods

### DIFF
--- a/Mantle/MTLModel.m
+++ b/Mantle/MTLModel.m
@@ -11,11 +11,6 @@
 #import "EXTScope.h"
 #import <objc/runtime.h>
 
-// This coupling is needed for backwards compatibility in MTLModel's deprecated
-// methods.
-#import "MTLJSONAdapter.h"
-#import "MTLModel+NSCoding.h"
-
 // The domain for errors originating from MTLModel.
 static NSString * const MTLModelErrorDomain = @"MTLModelErrorDomain";
 


### PR DESCRIPTION
**Disclaimer**: I may be doing something very wrong. I apologize if that's the case :)

I was using `Mantle` as a submodule and just compiling the Mantle source along with my project and that worked just fine, that's why I think this may be something I'm doing wrong.

The `Pods` target fails to compile when I added the `Mantle` dependency because it complained that some classes were duplicated.

Removing those imports seems to fix this?
