### PR TITLE
Failing gracefully for inconsistent APIs

### DIFF
--- a/Mantle/NSValueTransformer+MTLPredefinedTransformerAdditions.m
+++ b/Mantle/NSValueTransformer+MTLPredefinedTransformerAdditions.m
@@ -51,6 +51,9 @@ NSString * const MTLBooleanValueTransformerName = @"MTLBooleanValueTransformerNa
 	return [MTLValueTransformer
 		reversibleTransformerWithForwardBlock:^ id (NSDictionary *JSONDictionary) {
 			if (JSONDictionary == nil) return nil;
+            if ([JSONDictionary isKindOfClass:[NSString class]] && ((NSString *)JSONDictionary).length == 0) {
+                return nil;
+            }
 
 			NSAssert([JSONDictionary isKindOfClass:NSDictionary.class], @"Expected a dictionary, got: %@", JSONDictionary);
 


### PR DESCRIPTION
I‘m using Mantle for model objects representing the objects of the Reddit API (https://github.com/reddit/reddit/wiki/JSON) and unfortunately the API behaves pretty inconsistent. Replies on a comment expect a dictionary (which I usually get), but when there are no replies the value sometimes is an empty string instead of nil.

I'm opening this Pull Request to start a discussion on how to handle such cases, I'm sure there are more problematic APIs out there - I don't know if you would want to include this kind of fallback/hack in Mantle though. Is the changed code reasonable for my use case or am I missing a better fix?
