### PR TITLE
Explicitly validate default values

### DIFF
--- a/Mantle.xcodeproj/project.pbxproj
+++ b/Mantle.xcodeproj/project.pbxproj
@@ -241,10 +241,10 @@
 		D064BA321613BA75004CA27A /* MTLTestNotificationObserver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MTLTestNotificationObserver.h; sourceTree = "<group>"; };
 		D064BA331613BA75004CA27A /* MTLTestNotificationObserver.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MTLTestNotificationObserver.m; sourceTree = "<group>"; };
 		D0760E7615FFBF330060F550 /* MTLModel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MTLModel.h; sourceTree = "<group>"; };
-		D0760E7715FFBF330060F550 /* MTLModel.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MTLModel.m; sourceTree = "<group>"; };
+		D0760E7715FFBF330060F550 /* MTLModel.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MTLModel.m; sourceTree = "<group>"; usesTabs = 1; };
 		D0760EC315FFCA250060F550 /* MTLModelSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MTLModelSpec.m; sourceTree = "<group>"; };
 		D0760EC715FFCA4E0060F550 /* MTLTestModel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MTLTestModel.h; sourceTree = "<group>"; };
-		D0760EC815FFCA4E0060F550 /* MTLTestModel.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MTLTestModel.m; sourceTree = "<group>"; };
+		D0760EC815FFCA4E0060F550 /* MTLTestModel.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MTLTestModel.m; sourceTree = "<group>"; usesTabs = 1; };
 		D08B5AAC16002694001FE685 /* MTLValueTransformer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MTLValueTransformer.h; sourceTree = "<group>"; };
 		D08B5AAD16002694001FE685 /* MTLValueTransformer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MTLValueTransformer.m; sourceTree = "<group>"; };
 		D08B5AB116002A23001FE685 /* MTLValueTransformerSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MTLValueTransformerSpec.m; sourceTree = "<group>"; };

--- a/Mantle/MTLModel.m
+++ b/Mantle/MTLModel.m
@@ -61,9 +61,17 @@ static void *MTLModelCachedPropertyKeysKey = &MTLModelCachedPropertyKeysKey;
 		// Mark this as being autoreleased, because validateValue may return
 		// a new object to be stored in this variable (and we don't want ARC to
 		// double-free or leak the old or new values).
-		__autoreleasing id value = dictionary[key] ?: [self valueForKey:key];
-	
-		if ([value isEqual:NSNull.null]) value = nil;
+		__autoreleasing id value = dictionary[key];
+
+		if (value == nil) {
+			// If there is no value in the dictionary, validate the default
+			// value that was potentially set in init instead.
+			value = [self valueForKey:key];
+		} else if ([value isEqual:NSNull.null]) {
+			// If there is a value in the dictionary and it is NSNull, treat it
+			// as nil.
+			value = nil;
+		}
 
 		@try {
 			if (![self validateValue:&value forKey:key error:error]) return nil;

--- a/MantleTests/MTLModelSpec.m
+++ b/MantleTests/MTLModelSpec.m
@@ -121,6 +121,14 @@ it(@"should fail to initialize if default values don't validate", ^{
 	expect(error.code).to.equal(MTLTestModelNameMissing);
 });
 
+it(@"should leave null default values unaffected", ^{
+	NSError *error = nil;
+	MTLNullPropertyModel *model = [[MTLNullPropertyModel alloc] initWithDictionary:@{} error:&error];
+	expect(model).notTo.beNil();
+	expect(model.null).to.equal(NSNull.null);
+
+	expect(error).to.beNil();
+});
 
 it(@"should merge two models together", ^{
 	MTLTestModel *target = [[MTLTestModel alloc] initWithDictionary:@{ @"name": @"foo", @"count": @(5) } error:NULL];

--- a/MantleTests/MTLTestModel.h
+++ b/MantleTests/MTLTestModel.h
@@ -51,3 +51,10 @@ extern const NSInteger MTLTestModelNameMissing;
 @property (nonatomic, copy) NSString *name;
 
 @end
+
+@interface MTLNullPropertyModel : MTLModel
+
+// Defaults to NSNull
+@property (nonatomic, strong) NSNull *null;
+
+@end

--- a/MantleTests/MTLTestModel.m
+++ b/MantleTests/MTLTestModel.m
@@ -152,3 +152,15 @@ static NSUInteger modelVersion = 1;
 }
 
 @end
+
+@implementation MTLNullPropertyModel
+
+- (id)init {
+	self = [super init];
+	if (self == nil) return nil;
+
+	self.null = NSNull.null;
+	return self;
+}
+
+@end


### PR DESCRIPTION
I am dealing with a model object that requires its `messageID` property to be set, yet there is not sane default value that I could chose in `-[RBMessage init]`. If `-[RBMessage initWithDictionary:error:]` is invoked without a `messageID` value in the dictionary, the current implementation will simply ignore that property.

I would then have to override `-[RBMessage initWithDictionary:error:]` and check whether all fields been set properly in the superclass' implementation. However, I'd much rather use the existing KVO validation logic of `-[RBMessage validateMessageID:error:]`.

I understand that this is not the fastest possible implementation, but I wanted to start the discussion with the smallest viable change set :wink:
