### PR TITLE
Remove crash when parsing a JSON array with *null* items in it

### DIFF
--- a/Mantle/NSValueTransformer+MTLPredefinedTransformerAdditions.m
+++ b/Mantle/NSValueTransformer+MTLPredefinedTransformerAdditions.m
@@ -50,7 +50,7 @@ NSString * const MTLBooleanValueTransformerName = @"MTLBooleanValueTransformerNa
 
 	return [MTLValueTransformer
 		reversibleTransformerWithForwardBlock:^ id (NSDictionary *JSONDictionary) {
-			if (JSONDictionary == nil) return nil;
+			if (JSONDictionary == nil || (id)JSONDictionary == NSNull.null) return nil;
 
 			NSAssert([JSONDictionary isKindOfClass:NSDictionary.class], @"Expected a dictionary, got: %@", JSONDictionary);
 


### PR DESCRIPTION
Hello!

This is a fix for a crash that turns up when `[MTLValueTransformer mtl_JSONDictionaryTransformerWithModelClass]` is used to map objects from a JSON array that contains **null** items passed on to Mantle as `NSNull`. 

E.g. Trying to map _objects_in_an_array_ works fine until it hits a _null_

```
"objects_in_an_array": [ 
{"test_id":"test_id_1"}, 
null, 
{"test_id":"test_id_3"}, 
{"test_id":"test_id_4"} ], 
"other_property" : "other_value"
```

In that case, the program asserts or crashes:

```
NSAssert([JSONDictionary isKindOfClass:NSDictionary.class], @"Expected a dictionary, got: %@", JSONDictionary);
```

With an additional check, the error is handled gracefully:

```
if (JSONDictionary == nil || JSONDictionary == NSNull.null) return nil;
```

Partnered in the crash & fix with /cc @orta 
