### PR TITLE
Add test to show URL Transformer bug

### DIFF
--- a/MantleTests/MTLPredefinedTransformerAdditionsSpec.m
+++ b/MantleTests/MTLPredefinedTransformerAdditionsSpec.m
@@ -23,6 +23,20 @@ it(@"should define a URL value transformer", ^{
 	expect([transformer reverseTransformedValue:nil]).to.beNil();
 });
 
+it(@"should define a URL value transformer", ^{
+	NSValueTransformer *transformer = [NSValueTransformer valueTransformerForName:MTLURLValueTransformerName];
+	expect(transformer).notTo.beNil();
+	expect([transformer.class allowsReverseTransformation]).to.beTruthy();
+    
+	NSString *URLString = @"http://www.exåmple.com/";
+	expect([transformer transformedValue:URLString]).to.equal([NSURL URLWithString:URLString]);
+	expect([transformer reverseTransformedValue:[NSURL URLWithString:URLString]]).to.equal(URLString);
+    
+	expect([transformer transformedValue:nil]).to.beNil();
+	expect([transformer reverseTransformedValue:nil]).to.beNil();
+});
+
+
 it(@"should define an NSNumber boolean value transformer", ^{
 	// Back these NSNumbers with ints, rather than booleans,
 	// to ensure that the value transformers are actually transforming.


### PR DESCRIPTION
This adds a test for a problem I've run into related to diacritics in NSStrings that I'm attempting to transform to NSURLs using the predefined NSURL transformer.

(Be gentle on my test case, I haven't used Specta/Expecta before but will now, it's great!)

The [URLValueTransformer included with Mantle](https://github.com/github/Mantle/blob/master/Mantle/NSValueTransformer%2BMTLPredefinedTransformerAdditions.m#L26) simply takes an NSString and passes it into NSURL's -URLWithString:. However NSURL has a [note](https://developer.apple.com/library/mac/documentation/Cocoa/Reference/Foundation/Classes/NSURL_Class/Reference/Reference.html#//apple_ref/doc/uid/20000301-BAJBBDIB) 

```
"This method expects URLString to contain any necessary percent escape codes,
which are ‘:’, ‘/’, ‘%’, ‘#’, ‘;’, and ‘@’. Note that ‘%’ escapes are translated via UTF-8."
```

So this will fail in the case I have provided, and simply return a nil value.

How should this be handled?

In my case, passing the string through **-stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding** will result in a successful transformation, but does that cover all cases?
