### PR TITLE
Remove mtl_firstObject, declare header so we can already use it in Xcode 4

### DIFF
--- a/Mantle/NSArray+MTLManipulationAdditions.h
+++ b/Mantle/NSArray+MTLManipulationAdditions.h
@@ -11,6 +11,7 @@
 @interface NSArray (MTLManipulationAdditions)
 
 // The first object in the array or nil if the array is empty.
+// Forwards to `firstObject` which has been first declared in iOS7, but works with iOS4/10.6.
 @property (nonatomic, readonly, strong) id mtl_firstObject;
 
 // Returns a new array without all instances of the given object.

--- a/Mantle/NSArray+MTLManipulationAdditions.m
+++ b/Mantle/NSArray+MTLManipulationAdditions.m
@@ -8,10 +8,17 @@
 
 #import "NSArray+MTLManipulationAdditions.h"
 
+@interface NSArray (MTLDeclarations)
+
+// This declaration is needed so Mantle can be compiled with SDK 6 / 10.8.
+- (id)firstObject;
+
+@end
+
 @implementation NSArray (MTLManipulationAdditions)
 
 - (id)mtl_firstObject {
-	return self.count > 0 ? self[0] : nil;
+	return self.firstObject;
 }
 
 - (instancetype)mtl_arrayByRemovingObject:(id)object {


### PR DESCRIPTION
As of iOS7, we don't need a custom firstObject accessor anymore and can use the method that was there all along. I've still added this to the headers so it will work with SDK6/Xcode4 as well.

Not sure how important backwards compatibility is here, I would simply drop this (or make mtl_firstObject that calls through to firstObject)
