### PR TITLE
[WIP] Add a cache for transformer objects.

### DIFF
--- a/MantleTests/MTLJSONAdapterSpec.m
+++ b/MantleTests/MTLJSONAdapterSpec.m
@@ -35,6 +35,31 @@ it(@"should initialize from JSON", ^{
 	expect(adapter.JSONDictionary).to.equal(JSONDictionary);
 });
 
+it(@"should initialize from JSON using the transformer cache", ^{
+	NSDictionary *values = @{
+							 @"username": NSNull.null,
+							 @"count": @"5",
+							 };
+
+	NSError *error = nil;
+	MTLJSONAdapter *adapter = [[MTLJSONAdapter alloc] initWithJSONDictionary:values modelClass:MTLTestModel.class error:&error];
+	expect(adapter).notTo.beNil();
+	expect(error).to.beNil();
+
+	MTLTestModel *model = (id)adapter.model;
+	expect(model).notTo.beNil();
+	expect(model.name).to.beNil();
+	expect(model.count).to.equal(5);
+
+	NSDictionary *JSONDictionary = @{
+									 @"username": NSNull.null,
+									 @"count": @"5",
+									 @"nested": @{ @"name": NSNull.null },
+									 };
+
+	expect(adapter.JSONDictionary).to.equal(JSONDictionary);
+});
+
 it(@"should initialize from a model", ^{
 	MTLTestModel *model = [MTLTestModel modelWithDictionary:@{
 		@"name": @"foobar",


### PR DESCRIPTION
I've ported this from the various changes/tweaks in the PSPDFKit-Branch of Mantle. This port isn't well-tested yet, but I'd like to hear opinions on it. We could cache all NSInvocation usages the same way (e.g. in `mergeValueForKey:fromModel:`), just the transformer calls turned out to be real hot spots in Instruments. We will also need an additional test for CoreData.

In my tests this greatly speeds up serialization/deserialization. The transformer objects are cached instead of being created/deleted all the time. We also save time by not requiring the NSInvocation and building up the selector. This is thread safe as well since we atomically save the cache object; in the worst case we would look up transformers more than once.

Downside: The cache is saved on the class object, so it won't ever be cleaned up. I don't see this as an issue though as transformers usually are very small objects.
