### PR TITLE
Remove inclusion of config.h fixes #124

### DIFF
--- a/Mantle/extobjc/metamacros.h
+++ b/Mantle/extobjc/metamacros.h
@@ -9,10 +9,6 @@
 #ifndef EXTC_METAMACROS_H
 #define EXTC_METAMACROS_H
 
-#ifdef HAVE_CONFIG_H
-#include "config.h"
-#endif
-
 /**
  * Executes one or more expressions (which may have a void type, such as a call
  * to a function that returns no value) and always returns true.


### PR DESCRIPTION
Other libraries define the `HAVE_CONFIG_H` condition to include
`config.h`, such as LibYAML or YAML.framework. When this happens
Mantle's extobjc tries to include its own `config.h` file which doesn't
exist. As this is not used in Mantle, so we can safely remove it.
