### PR TITLE
Expose MTLReversibleValueTransformer interface to make it easier to subclass.

### DIFF
--- a/Mantle/MTLValueTransformer.h
+++ b/Mantle/MTLValueTransformer.h
@@ -27,3 +27,10 @@ typedef id (^MTLValueTransformerBlock)(id);
 + (instancetype)reversibleTransformerWithForwardBlock:(MTLValueTransformerBlock)forwardBlock reverseBlock:(MTLValueTransformerBlock)reverseBlock;
 
 @end
+
+//
+// Any MTLValueTransformer supporting reverse transformation. Necessary because
+// +allowsReverseTransformation is a class method.
+//
+@interface MTLReversibleValueTransformer : MTLValueTransformer
+@end

--- a/Mantle/MTLValueTransformer.m
+++ b/Mantle/MTLValueTransformer.m
@@ -8,13 +8,6 @@
 
 #import "MTLValueTransformer.h"
 
-//
-// Any MTLValueTransformer supporting reverse transformation. Necessary because
-// +allowsReverseTransformation is a class method.
-//
-@interface MTLReversibleValueTransformer : MTLValueTransformer
-@end
-
 @interface MTLValueTransformer ()
 
 @property (nonatomic, copy, readonly) MTLValueTransformerBlock forwardBlock;


### PR DESCRIPTION
Expose the MTLReversibleValueTransformer interface since overriding 
+transformedValueClass is useful in the context of Core Data transformable attributes.
