### PR TITLE
Change submodule URLs to HTTPS (from Git) to avoid firewalls that block ...

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "MantleTests/expecta"]
 	path = MantleTests/expecta
-	url = git://github.com/github/expecta.git
+	url = https://github.com/github/expecta.git
 [submodule "MantleTests/specta"]
 	path = MantleTests/specta
-	url = git://github.com/github/specta.git
+	url = https://github.com/github/specta.git
 [submodule "Configuration"]
 	path = Configuration
 	url = https://github.com/jspahrsummers/xcconfigs.git


### PR DESCRIPTION
Change submodule URLs to HTTPS (from Git) to avoid firewalls that block that port.
