### PR TITLE
Adding subclassing notes to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,7 +295,7 @@ For example:
 
 @interface XYChild : MTLModel
 
-@property (readonly, nonatomic, strong) XYParent *parent;
+@property (readonly, nonatomic, weak) XYParent *parent;
 
 @end
 ```


### PR DESCRIPTION
I took a shot at adding subclassing notes to the README, mostly inspired by #88 but I also threw in `-validate:`.

[all hail the markdown preview eggplant :eggplant:](https://github.com/github/Mantle/tree/subclassing-notes#subclassing-notes)

Let me know what you think.

Closes #88
