### PR TITLE
Add installation guide to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,11 +130,14 @@ typedef enum : NSUInteger {
 Whew, that's a lot of boilerplate for something so simple! And, even then, there
 are some problems that this example doesn't address:
 
- * If the `url` or `html_url` field is missing, `+[NSURL URLWithString:]` will throw an exception.
+ * If the `url` or `html_url` field is missing, `+[NSURL URLWithString:]` will
+   throw an exception.
  * There's no way to update a `GHIssue` with new data from the server.
  * There's no way to turn a `GHIssue` _back_ into JSON.
- * `GHIssueState` shouldn't be encoded as-is. If the enum changes in the future, existing archives might break.
- * If the interface of `GHIssue` changes down the road, existing archives might break.
+ * `GHIssueState` shouldn't be encoded as-is. If the enum changes in the future,
+   existing archives might break.
+ * If the interface of `GHIssue` changes down the road, existing archives might
+   break.
 
 ## Why Not Use Core Data?
 
@@ -155,8 +158,8 @@ If you're just trying to access some JSON objects, Core Data can be a lot of
 work for little gain.
 
 Nonetheless, if you're using or want to use Core Data in your app already,
-Mantle can still be a convenient translation layer between the API and your managed
-model objects.
+Mantle can still be a convenient translation layer between the API and your
+managed model objects.
 
 ## MTLModel
 
@@ -453,28 +456,26 @@ Mantle supports OS X 10.7+ and iOS 5.0+.
 
 To add Mantle to your application:
 
- 1. Add the Mantle repository as a submodule of your application's
-    repository.
+ 1. Add the Mantle repository as a submodule of your application's repository.
  1. Run `script/bootstrap` from within the Mantle folder.
- 1. Drag and drop `Mantle.xcodeproj` into your
-    application's Xcode project or workspace.
- 1. On the "Build Phases" tab of your application target, add Mantle to the "Link
-    Binary With Libraries" phase.
+ 1. Drag and drop `Mantle.xcodeproj` into your application's Xcode project or
+    workspace.
+ 1. On the "Build Phases" tab of your application target, add Mantle to the
+    "Link Binary With Libraries" phase.
     * **On iOS**, add `libMantle.a`.
     * **On OS X**, add `Mantle.framework`. Mantle must also be added to any
-      "Copy Frameworks" build phase. If you don't already have one, simply add
-      a "Copy Files" build phase and target the "Frameworks" destination.
- 1. Add `"$(BUILD_ROOT)/../IntermediateBuildFilesPath/UninstalledProducts/include"
-    $(inherited)` to the "Header Search Paths" build setting (this is only
+      "Copy Frameworks" build phase. If you don't already have one, simply add a
+      "Copy Files" build phase and target the "Frameworks" destination.
+ 1. Add `"$(BUILD_ROOT)/../IntermediateBuildFilesPath/UninstalledProducts/include" $(inherited)`
+    to the "Header Search Paths" build setting (this is only
     necessary for archive builds, but it has no negative effect otherwise).
  1. **For iOS targets**, add `-ObjC` to the "Other Linker Flags" build setting.
- 1. **If you added Mantle to a project (not a workspace)**, you will also need to
-    add the appropriate Mantle target to the "Target Dependencies" of your
+ 1. **If you added Mantle to a project (not a workspace)**, you will also need
+    to add the appropriate Mantle target to the "Target Dependencies" of your
     application.
 
 If you would prefer to use [CocoaPods](http://cocoapods.org), there are some
-[Mantle
-podspecs](https://github.com/CocoaPods/Specs/tree/master/Mantle) that
+[Mantle podspecs](https://github.com/CocoaPods/Specs/tree/master/Mantle) that
 have been generously contributed by third parties.
 
 ## License


### PR DESCRIPTION
This pull request introduces an installation guide to the README file. To remain consistent, I based the guide on [ReactiveCocoa's one](https://github.com/ReactiveCocoa/ReactiveCocoa#system-requirements) which is also developed by GitHub, [I believe](https://github.com/blog/1107-reactivecocoa-for-a-better-world).

Sinc the 6th point of the installation guide instructs to add an `-ObjC` linker flag, this pull request closes #93.
#### Changes
- Removed the "Getting Started" section
- Added "System Requirements" and "Installing Mantle" sections
- Improved formatting in some places (hard-wrapped at 80 chars to match the rest of the README)
