### PR TITLE
Added Error when the JSONDictionary received is nil

### DIFF
--- a/Mantle/MTLJSONAdapter.h
+++ b/Mantle/MTLJSONAdapter.h
@@ -98,8 +98,7 @@ extern const NSInteger MTLJSONAdapterErrorInvalidJSONDictionary;
 //
 // JSONDictionary - A dictionary representing JSON data. This should match the
 //                  format returned by NSJSONSerialization. If this argument is
-//                  nil, the method returns nil and set error to 
-//					MTLJSONAdapterErrorInvalidJSONDictionary.
+//                  nil, the method returns nil and an error with code MTLJSONAdapterErrorInvalidJSONDictionary.
 // modelClass     - The MTLModel subclass to attempt to parse from the JSON.
 //                  This class must conform to <MTLJSONSerializing>. This
 //                  argument must not be nil.

--- a/Mantle/MTLJSONAdapter.m
+++ b/Mantle/MTLJSONAdapter.m
@@ -79,8 +79,7 @@ static NSString * const MTLJSONAdapterThrownExceptionErrorKey = @"MTLJSONAdapter
 				NSLocalizedDescriptionKey: NSLocalizedString(@"Invalid JSONDictionary", @""),
 				NSLocalizedFailureReasonErrorKey: NSLocalizedString(@"The JSONDictionary parameter is invalid.", @"")
 			};
-			*error = [NSError errorWithDomain:MTLJSONAdapterErrorDomain code:MTLJSONAdapterErrorInvalidJSONDictionary
-									 userInfo:userInfo];
+			*error = [NSError errorWithDomain:MTLJSONAdapterErrorDomain code:MTLJSONAdapterErrorInvalidJSONDictionary userInfo:userInfo];
 		}
 		return nil;
 	}

--- a/MantleTests/MTLJSONAdapterSpec.m
+++ b/MantleTests/MTLJSONAdapterSpec.m
@@ -73,7 +73,7 @@ it(@"should initialize nested key paths from JSON", ^{
 	expect([MTLJSONAdapter JSONDictionaryFromModel:model]).to.equal(values);
 });
 
-it(@"should return nil with a nil JSON dictionary, and invalid json error", ^{
+it(@"should return nil and an error with a nil JSON dictionary", ^{
 	NSError *error = nil;
 	MTLJSONAdapter *adapter = [[MTLJSONAdapter alloc] initWithJSONDictionary:nil modelClass:MTLTestModel.class error:&error];
 	expect(adapter).to.beNil();
@@ -153,6 +153,3 @@ it(@"should fail to initialize if JSON dictionary is nil", ^{
 });
 
 SpecEnd
-
-
-


### PR DESCRIPTION
There was no error neither object result when the JSONDictionary used for the model was a nil value. So there was no way of knowing what happened.

In this branch I added a specific error for this situation.
