### PR TITLE
Ensure that relationships are updated for an object matching a uniqueness constraint

### DIFF
--- a/Mantle/MTLManagedObjectAdapter.m
+++ b/Mantle/MTLManagedObjectAdapter.m
@@ -438,14 +438,14 @@ static const NSInteger MTLManagedObjectAdapterErrorExceptionThrown = 1;
 				} else {
 					relationshipCollection = [NSMutableSet set];
 				}
-				
+
 				for (MTLModel *model in value) {
 					NSManagedObject *nestedObject = objectForRelationshipFromModel(model);
 					if (nestedObject == nil) return NO;
 
 					[relationshipCollection addObject:nestedObject];
 				}
-				
+
 				[managedObject setValue:relationshipCollection forKey:managedObjectKey];
 			} else {
 				NSManagedObject *nestedObject = objectForRelationshipFromModel(value);

--- a/MantleTests/MTLManagedObjectAdapterSpec.m
+++ b/MantleTests/MTLManagedObjectAdapterSpec.m
@@ -229,7 +229,7 @@ describe(@"with a confined context", ^{
 
 			expect(parentOne.objectID).to.equal(parentTwo.objectID);
 		});
-		
+
 		it(@"should update relationships for an existing object", ^{
 			NSError *error;
 			MTLParent *parentOne = [MTLManagedObjectAdapter managedObjectFromModel:parentModel insertingIntoContext:context error:&error];
@@ -237,7 +237,7 @@ describe(@"with a confined context", ^{
 			expect(error).to.beNil();
 			expect(parentOne.orderedChildren).to.haveCountOf(3);
 			expect(parentOne.unorderedChildren).to.haveCountOf(3);
-			
+
 			MTLChild *child1Parent1 = parentOne.orderedChildren[0];
 			MTLChild *child2Parent1 = parentOne.orderedChildren[1];
 			MTLChild *child3Parent1 = parentOne.orderedChildren[2];
@@ -250,15 +250,15 @@ describe(@"with a confined context", ^{
 			expect(error).to.beNil();
 			expect(parentTwo.orderedChildren).to.haveCountOf(2);
 			expect(parentTwo.unorderedChildren).to.haveCountOf(2);
-			
+
 			for (MTLChild *child in parentTwo.orderedChildren) {
 				expect(child.childID).notTo.equal(child2Parent1.childID);
 			}
-			
+
 			for (MTLChild *child in parentTwo.unorderedChildren) {
 				expect(child.childID).notTo.equal(childToDeleteModel.childID);
 			}
-			
+
 			MTLChild *child1Parent2 = parentTwo.orderedChildren[0];
 			MTLChild *child2Parent2 = parentTwo.orderedChildren[1];
 			expect(child1Parent2).to.equal(child1Parent1);


### PR DESCRIPTION
Previously, objects in a relationship are added/updated, but they are not deleted if not present in the model's relationship anymore.

Simple case to reproduce the issue:

**Parent**
- uniqueId (used for the uniquing predicate)
- children (to many relationship to Child)

**Child**
- uniqueId (again, used the uniquing predicate)
- name (string)
- parent (to one relationship to Parent)

I insert a Parent with id 1 and children with ids 100, 101, 102.

``` objc
Parent *p1 = [MTLManagedObjectAdapter managedObjectFromModel:parentModel insertingIntoContext:context error:&error];
```

And now, I have the same parent (id 1), but with children ids 100, 102, 103.

``` objc
Parent *p2 = [MTLManagedObjectAdapter managedObjectFromModel:parentModel insertingIntoContext:context error:&error];
```

Here `p2.children` contains all 4 children 100, **101**, 102 and 103
- new children are added
- existing children are updated if needed
- but **deleted children are still here**
