### PR TITLE
[WIP] Add array mapping value transformer

### DIFF
--- a/Mantle/NSValueTransformer+MTLPredefinedTransformerAdditions.h
+++ b/Mantle/NSValueTransformer+MTLPredefinedTransformerAdditions.h
@@ -61,6 +61,14 @@ extern NSString * const MTLBooleanValueTransformerName;
 // transformations, and from objects to keys for reverse transformations.
 + (NSValueTransformer *)mtl_valueMappingTransformerWithDictionary:(NSDictionary *)dictionary;
 
+// A reversible value transformer which applies a transformer to each element of an array
+//
+// transformer - The NSValueTransformer to be applied to each element
+//
+// Returns a transformer which will apply the provided transformer
+// to each element in an NSArray
++ (NSValueTransformer *)mtl_arrayMappingTransformerWithTransformer:(NSValueTransformer *)transformer;
+
 @end
 
 @interface NSValueTransformer (UnavailableMTLPredefinedTransformerAdditions)

--- a/Mantle/NSValueTransformer+MTLPredefinedTransformerAdditions.m
+++ b/Mantle/NSValueTransformer+MTLPredefinedTransformerAdditions.m
@@ -134,4 +134,31 @@ NSString * const MTLBooleanValueTransformerName = @"MTLBooleanValueTransformerNa
 	}];
 }
 
++ (NSValueTransformer *)mtl_arrayMappingTransformerWithTransformer:(NSValueTransformer *)transformer
+{
+	NSParameterAssert(transformer != nil);
+	NSParameterAssert([transformer.class allowsReverseTransformation]);
+	
+	return [MTLValueTransformer reversibleTransformerWithForwardBlock:^NSArray *(NSArray *values) {
+		if (![values isKindOfClass:NSArray.class]) return nil;
+		NSMutableArray *transformedValues = [NSMutableArray arrayWithCapacity:values.count];
+		for (NSString *value in values) {
+			id transformedValue = [transformer transformedValue:value];
+			if (transformedValue == nil) continue;
+			[transformedValues addObject:transformedValue];
+		}
+		return transformedValues;
+		
+	} reverseBlock:^NSArray *(NSArray *values) {
+		if (![values isKindOfClass:NSArray.class]) return nil;
+		NSMutableArray *transformedValues = [NSMutableArray arrayWithCapacity:values.count];
+		for (NSString *value in values) {
+			id transformedValue = [transformer reverseTransformedValue:value];
+			if (transformedValue == nil) continue;
+			[transformedValues addObject:transformedValue];
+		}
+		return transformedValues;
+	}];
+}
+
 @end


### PR DESCRIPTION
This transformer applies the given transformer to each element of an array. I've found this useful where my JSON contains arrays of strings (e.g. URLs) and other non-dictionary values that can't be represented by an `MTLModel`.

At present this requires a reversible transformer. I'm not sure whether one method (`mtl_arrayMappingTransformerWithTransformer:`) can handle both reversible and one-way transformers, but a second method could be added for this case.
