### PR TITLE
Fix a crash when receving something different than a NSDictionary

### DIFF
--- a/Mantle/MTLJSONAdapter.m
+++ b/Mantle/MTLJSONAdapter.m
@@ -72,7 +72,7 @@ static NSString * const MTLJSONAdapterThrownExceptionErrorKey = @"MTLJSONAdapter
 	NSParameterAssert([modelClass isSubclassOfClass:MTLModel.class]);
 	NSParameterAssert([modelClass conformsToProtocol:@protocol(MTLJSONSerializing)]);
 
-	if (JSONDictionary == nil || (![JSONDictionary isKindOfClass:NSDictionary.class])) {
+	if (JSONDictionary == nil || ![JSONDictionary isKindOfClass:NSDictionary.class]) {
 		if (error != NULL) {
 			NSDictionary *userInfo = @{
 				NSLocalizedDescriptionKey: NSLocalizedString(@"Missing JSON dictionary", @""),

--- a/MantleTests/MTLJSONAdapterSpec.m
+++ b/MantleTests/MTLJSONAdapterSpec.m
@@ -84,7 +84,7 @@ it(@"should return nil and an error with a nil JSON dictionary", ^{
 
 it(@"should return nil and an error with a wrong data type as dictionary", ^{
 	NSError *error = nil;
-	id wrongDictionary = [NSString new];
+	id wrongDictionary = @"";
 	MTLJSONAdapter *adapter = [[MTLJSONAdapter alloc] initWithJSONDictionary:wrongDictionary modelClass:MTLTestModel.class error:&error];
 	expect(adapter).to.beNil();
 	expect(error).notTo.beNil();


### PR DESCRIPTION
Fix a crash when receving something different than a NSDictionary to build the model, which can easily happen if the json structure changes
