### PR TITLE
Fix a crash when key is null in mtl_valueMappingTransformer

### DIFF
--- a/Mantle/NSValueTransformer+MTLPredefinedTransformerAdditions.m
+++ b/Mantle/NSValueTransformer+MTLPredefinedTransformerAdditions.m
@@ -121,7 +121,7 @@ NSString * const MTLBooleanValueTransformerName = @"MTLBooleanValueTransformerNa
 	NSParameterAssert(dictionary.count == [[NSSet setWithArray:dictionary.allValues] count]);
 
 	return [MTLValueTransformer reversibleTransformerWithForwardBlock:^(id<NSCopying> key) {
-		return dictionary[key];
+		return dictionary[key ?: NSNull.null];
 	} reverseBlock:^(id object) {
 		__block id result = nil;
 		[dictionary enumerateKeysAndObjectsUsingBlock:^(id key, id anObject, BOOL *stop) {


### PR DESCRIPTION
I found a issue that occurs when i get nil key in mtl_valueMappingTransformerWithDictionary and fixed it.
