### PR TITLE
MTLManagedObjectAdapter: Fix a bug where errors are silently handled

### DIFF
--- a/Mantle/MTLManagedObjectAdapter.m
+++ b/Mantle/MTLManagedObjectAdapter.m
@@ -502,8 +502,8 @@ static const NSInteger MTLManagedObjectAdapterErrorExceptionThrown = 1;
 		}
 	}];
 
-	if (managedObject != nil && ![managedObject validateForInsert:error]) {
-		performInContext(context, ^ id {
+	if (managedObject != nil && ![managedObject validateForInsert:&tmpError]) {
+		managedObject = performInContext(context, ^ id {
 			[context deleteObject:managedObject];
 			return nil;
 		});

--- a/MantleTests/MTLCoreDataTestModels.h
+++ b/MantleTests/MTLCoreDataTestModels.h
@@ -23,6 +23,11 @@
 
 @end
 
+// Model for Parent entity which doesn't serialize required properties
+@interface MTLParentIncorrectTestModel : MTLModel <MTLManagedObjectSerializing>
+
+@end
+
 // Corresponds to the `Child` entity.
 @interface MTLChildTestModel : MTLModel <MTLManagedObjectSerializing>
 

--- a/MantleTests/MTLCoreDataTestModels.m
+++ b/MantleTests/MTLCoreDataTestModels.m
@@ -42,6 +42,18 @@
 
 @end
 
+@implementation MTLParentIncorrectTestModel
+
++ (NSString *)managedObjectEntityName {
+	return @"Parent";
+}
+
++ (NSDictionary *)managedObjectKeysByPropertyKey {
+	return @{};
+}
+
+@end
+
 @implementation MTLChildTestModel
 
 + (NSString *)managedObjectEntityName {

--- a/MantleTests/MTLManagedObjectAdapterSpec.m
+++ b/MantleTests/MTLManagedObjectAdapterSpec.m
@@ -226,6 +226,16 @@ describe(@"with a confined context", ^{
 			expect(error).notTo.beNil();
 		});
 
+		it(@"should return an error if model doesn't validate for insert", ^{
+			MTLParentIncorrectTestModel *parentModel = [MTLParentIncorrectTestModel modelWithDictionary:@{} error:NULL];
+
+			NSError *error;
+			NSManagedObject *managedObject = [MTLManagedObjectAdapter managedObjectFromModel:parentModel insertingIntoContext:context error:&error];
+
+			expect(managedObject).to.beNil();
+			expect(error).notTo.beNil();
+		});
+
 		it(@"should respect the uniqueness constraint", ^{
 			NSError *errorOne;
 			MTLParent *parentOne = [MTLManagedObjectAdapter managedObjectFromModel:parentModel insertingIntoContext:context error:&errorOne];


### PR DESCRIPTION
It was using `error` but this error is replaced later in the method and never passed as an error.

``` objective-c
if (error != NULL) {
    *error = tmpError;
}
```
