### PR TITLE
Removed variables that where causing compiler error.

### DIFF
--- a/Mantle/MTLJSONAdapter.m
+++ b/Mantle/MTLJSONAdapter.m
@@ -14,9 +14,6 @@ NSString * const MTLJSONAdapterErrorDomain = @"MTLJSONAdapterErrorDomain";
 const NSInteger MTLJSONAdapterErrorNoClassFound = 2;
 const NSInteger MTLJSONAdapterErrorInvalidJSONDictionary = 3;
 
-// An exception was thrown and caught.
-static const NSInteger MTLJSONAdapterErrorExceptionThrown = 1;
-
 // Associated with the NSException that was caught.
 static NSString * const MTLJSONAdapterThrownExceptionErrorKey = @"MTLJSONAdapterThrownException";
 

--- a/Mantle/MTLManagedObjectAdapter.m
+++ b/Mantle/MTLManagedObjectAdapter.m
@@ -34,9 +34,6 @@ static id performInContext(NSManagedObjectContext *context, id (^block)(void)) {
 	return result;
 }
 
-// An exception was thrown and caught.
-static const NSInteger MTLManagedObjectAdapterErrorExceptionThrown = 1;
-
 @interface MTLManagedObjectAdapter ()
 
 // The MTLModel subclass being serialized or deserialized.


### PR DESCRIPTION
- The error happened when the Debug.xcconfig conflicting flag was removed to compile Mantle under Xcode 5.1.
