### PR TITLE
Asserting that an entity has a MOC

### DIFF
--- a/Mantle/MTLManagedObjectAdapter.m
+++ b/Mantle/MTLManagedObjectAdapter.m
@@ -132,6 +132,7 @@ static id performInContext(NSManagedObjectContext *context, id (^block)(void)) {
 	NSAssert(entity != nil, @"%@ returned a nil +entity", managedObject);
 
 	NSManagedObjectContext *context = managedObject.managedObjectContext;
+	NSAssert(context != nil, @"%@ returned a nil +managedObjectContext", managedObject);
 
 	NSDictionary *managedObjectProperties = entity.propertiesByName;
 	MTLModel *model = [[self.modelClass alloc] init];


### PR DESCRIPTION
I'll save the next poor sucker the hassle of diagnosing this the long way.

(For those playing at home, in my case, when `GCC_OPTIMIZATION_LEVEL` == `0`, it worked fine. I was only getting errors in prod builds. Don't be a fool like me, and keep a reference to your MOC so you can, you know, do work within it.)
