### PR TITLE
Added support for deserializing into unrelated types.

### DIFF
--- a/Mantle/NSValueTransformer+MTLPredefinedTransformerAdditions.h
+++ b/Mantle/NSValueTransformer+MTLPredefinedTransformerAdditions.h
@@ -33,6 +33,17 @@ extern NSString * const MTLBooleanValueTransformerName;
 // values back and forth.
 + (NSValueTransformer *)mtl_JSONDictionaryTransformerWithModelClass:(Class)modelClass;
 
+// Creates a reversible transformer to convert a JSON dictionary into a MTLModel
+// object, and vice-versa.
+//
+// classFor - A callback that returns the MTLModel subclass to attempt to parse
+//            from the JSON. The returned class must conform to <MTLJSONSerializing>.
+//            This argument must not be nil.
+//
+// Returns a reversible transformer which uses MTLJSONAdapter for transforming
+// values back and forth.
++ (NSValueTransformer *)mtl_JSONDictionaryTransformerWithModelClassFrom:(Class (^)(id JSONDictionary))transformerFromDictionary;
+
 // Creates a reversible transformer to convert an array of JSON dictionaries
 // into an array of MTLModel objects, and vice-versa.
 //

--- a/MantleTests/MTLPredefinedTransformerAdditionsSpec.m
+++ b/MantleTests/MTLPredefinedTransformerAdditionsSpec.m
@@ -80,6 +80,33 @@ describe(@"JSON transformers", ^{
 		});
 	});
 
+	describe(@"dictionary transformer with callback", ^{
+		__block NSValueTransformer *transformer;
+		
+		__block MTLTestModel *model;
+		__block NSDictionary *JSONDictionary;
+		
+		before(^{
+			model = [[MTLTestModel alloc] init];
+			JSONDictionary = [MTLJSONAdapter JSONDictionaryFromModel:model];
+			
+			transformer = [NSValueTransformer mtl_JSONDictionaryTransformerWithModelClassFrom:^Class(id JSONDictionary) {
+				expect(JSONDictionary).toNot.beNil();
+				return MTLTestModel.class;
+			}];
+			expect(transformer).notTo.beNil();
+		});
+		
+		it(@"should transform a JSON dictionary into a model", ^{
+			expect([transformer transformedValue:JSONDictionary]).to.equal(model);
+		});
+		
+		it(@"should transform a model into a JSON dictionary", ^{
+			expect([transformer.class allowsReverseTransformation]).to.beTruthy();
+			expect([transformer reverseTransformedValue:model]).to.equal(JSONDictionary);
+		});
+	});
+	
 	describe(@"external representation array transformer", ^{
 		__block NSValueTransformer *transformer;
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ typedef enum : NSUInteger {
     _URL = [NSURL URLWithString:dictionary[@"url"]];
     _HTMLURL = [NSURL URLWithString:dictionary[@"html_url"]];
     _number = dictionary[@"number"];
-    
+
     if ([dictionary[@"state"] isEqualToString:@"open"]) {
         _state = GHIssueStateOpen;
     } else if ([dictionary[@"state"] isEqualToString:@"closed"]) {
@@ -431,6 +431,37 @@ NSDictionary *pictureMessage = @{
 XYTextMessage *messageA = [MTLJSONAdapter modelOfClass:XYMessage.class fromJSONDictionary:textMessage error:NULL];
 
 XYPictureMessage *messageB = [MTLJSONAdapter modelOfClass:XYMessage.class fromJSONDictionary:pictureMessage error:NULL];
+```
+
+Mantle also supports deserializing properties into unrelated types. In the following example `XYCPIPPacket` and
+`XYPostcard` only share a protocol.
+
+```objc
+@protocol XYMessage<NSObject>
+@property (nonatomic, copy, readonly) NSString *body;
+@end
+
+@interface XYTCPIPPacket
+@property (nonatomic, copy, readonly) NSString *body;
+@end
+
+@interface XYPostcard
+@property (nonatomic, copy, readonly) NSString *body;
+@end
+
+@interface XYEnvelope
+@property (nonatomic, retain) id <XYMessage> message;
+@end
+
+@implementation XYEnvelope
+
++ (NSValueTransformer *)messageJSONTransformer {
+    return [MTLValueTransformer mtl_JSONDictionaryTransformerWithModelClassFrom:^Class(id JSONDictionary) {
+        return NSClassFromString(JSONDictionary[@"type"]); // can be XYTCPIPPacket or XYPostcard
+    }];
+}
+
+@end
 ```
 
 ## Persistence


### PR DESCRIPTION
Sometimes you want polymorphic behavior, but you don't want polymorphic types. The example below is a message that can be put in an envelope, but the only thing in common between a TCP/IP packet and a postcard is that they have a body. You only want them to implement a common protocol.

This extends `mtl_JSONDictionaryTransformerWithModelClass` with a `mtl_JSONDictionaryTransformerWithModelClassFrom` that takes a block that lets you decide what class to use for deserialization, dynamically. This way you can examine the data at runtime and, for example, return a type based on a "type" field of the JSON data itself.

``` objc
@protocol XYMessage<NSObject>
@property (nonatomic, copy, readonly) NSString *body;
@end

@interface XYTCPIPPacket
@property (nonatomic, copy, readonly) NSString *body;
@end

@interface XYPostcard
@property (nonatomic, copy, readonly) NSString *body;
@end

@interface XYEnvelope
@property (nonatomic, retain) id <XYMessage> message;
@end

@implementation XYEnvelope

+ (NSValueTransformer *)messageJSONTransformer {
    return [MTLValueTransformer mtl_JSONDictionaryTransformerWithModelClassFrom:^Class(id JSONDictionary) {
        return NSClassFromString(JSONDictionary[@"type"]); // can be XYTCPIPPacket or XYPostcard
    }];
}

@end
```
