### PR TITLE
Assertion for nil MOC, take 2

### DIFF
--- a/Mantle/MTLManagedObjectAdapter.m
+++ b/Mantle/MTLManagedObjectAdapter.m
@@ -22,7 +22,7 @@ const NSInteger MTLManagedObjectAdapterErrorUniqueFetchRequestFailed = 7;
 
 // Performs the given block in the context's queue, if it has one.
 static id performInContext(NSManagedObjectContext *context, id (^block)(void)) {
-	if (context.concurrencyType == NSConfinementConcurrencyType) {
+	if (context == nil || context.concurrencyType == NSConfinementConcurrencyType) {
 		return block();
 	}
 
@@ -132,6 +132,7 @@ static id performInContext(NSManagedObjectContext *context, id (^block)(void)) {
 	NSAssert(entity != nil, @"%@ returned a nil +entity", managedObject);
 
 	NSManagedObjectContext *context = managedObject.managedObjectContext;
+	NSAssert(!(context == nil && managedObject.isFault), @"%@ returned a nil +managedObjectContext for faulted managed object", managedObject);
 
 	NSDictionary *managedObjectProperties = entity.propertiesByName;
 	MTLModel *model = [[self.modelClass alloc] init];

--- a/MantleTests/MTLManagedObjectAdapterSpec.m
+++ b/MantleTests/MTLManagedObjectAdapterSpec.m
@@ -314,6 +314,49 @@ describe(@"with a main queue context", ^{
 	});
 });
 
+describe(@"without context", ^{
+	__block NSManagedObjectContext *context; // used for entity descriptions, not for persistence
+	__block MTLParent *parent;
+
+	__block NSDate *date;
+	__block NSString *numberString;
+	__block NSString *string;
+
+	beforeEach(^{
+		context = [[NSManagedObjectContext alloc] initWithConcurrencyType:NSMainQueueConcurrencyType];
+		expect(context).notTo.beNil();
+
+		context.undoManager = nil;
+		context.persistentStoreCoordinator = persistentStoreCoordinator;
+
+		date = [NSDate date];
+		numberString = @"123456789";
+		string = @"foobar";
+
+		NSEntityDescription *parentEntity = [NSEntityDescription entityForName:@"Parent" inManagedObjectContext:context];
+		expect(parentEntity).notTo.beNil();
+
+		parent = (MTLParent *)[[NSManagedObject alloc] initWithEntity:parentEntity insertIntoManagedObjectContext:nil];
+		expect(parent).notTo.beNil();
+		expect(parent.managedObjectContext).to.beNil();
+
+		parent.date = date;
+		parent.number = @([numberString integerValue]);
+		parent.string = string;
+	});
+
+	it(@"should serialize to model without context", ^{
+		NSError *error = nil;
+		MTLParentTestModel *parentModel = [MTLManagedObjectAdapter modelOfClass:MTLParentTestModel.class fromManagedObject:parent error:&error];
+		expect(parentModel).to.beKindOf(MTLParentTestModel.class);
+		expect(error).to.beNil();
+
+		expect(parentModel.date).to.equal(date);
+		expect(parentModel.numberString).to.equal(numberString);
+		expect(parentModel.requiredString).to.equal(string);
+	});
+});
+
 describe(@"with a child that fails serialization", ^{
 	__block NSManagedObjectContext *context;
 	


### PR DESCRIPTION
Okay, this should satisfy standard use cases of:
 1. Non-faulted MO with context
 1. Faulted MO without context (will throw assertion)
 1. Non-faulted MO without context (will work a-okay)

And, to be sure, I added a test to cover the use case for non-faulted/missing MOC.