### PR TITLE
Fixed incorrect error descriptions in JSONArray transformer

### DIFF
--- a/Mantle/NSValueTransformer+MTLPredefinedTransformerAdditions.m
+++ b/Mantle/NSValueTransformer+MTLPredefinedTransformerAdditions.m
@@ -180,7 +180,7 @@ NSString * const MTLBooleanValueTransformerName = @"MTLBooleanValueTransformerNa
 				if (![JSONDictionary isKindOfClass:NSDictionary.class]) {
 					if (error != NULL) {
 						NSDictionary *userInfo = @{
-							NSLocalizedDescriptionKey: NSLocalizedString(@"Could not convert JSON array to model array", @""),
+							NSLocalizedDescriptionKey: NSLocalizedString(@"Could not convert JSON dictionary to model", @""),
 							NSLocalizedFailureReasonErrorKey: [NSString stringWithFormat:NSLocalizedString(@"Expected an NSDictionary or an NSNull, got: %@.", @""), JSONDictionary],
 							MTLTransformerErrorHandlingInputValueErrorKey : JSONDictionary
 						};
@@ -229,8 +229,8 @@ NSString * const MTLBooleanValueTransformerName = @"MTLBooleanValueTransformerNa
 				if (![model isKindOfClass:MTLModel.class]) {
 					if (error != NULL) {
 						NSDictionary *userInfo = @{
-							NSLocalizedDescriptionKey: NSLocalizedString(@"Could not convert JSON array to model array", @""),
-							NSLocalizedFailureReasonErrorKey: [NSString stringWithFormat:NSLocalizedString(@"Expected a MTLModel or an NSNull, got: %@.", @""), model],
+							NSLocalizedDescriptionKey: NSLocalizedString(@"Could not convert model object to JSON dictionary", @""),
+							NSLocalizedFailureReasonErrorKey: [NSString stringWithFormat:NSLocalizedString(@"Expected an MTLModel or an NSNull, got: %@.", @""), model],
 							MTLTransformerErrorHandlingInputValueErrorKey : model
 						};
 


### PR DESCRIPTION
A couple of the error descriptions in the JSON Array transformer are incorrect. 

I was looking at this in relation to #191 and how to bubble up errors and noticed that the errors thrown by the array transformer in attempting to transform each dictionary are the same as those the dictionary transformer would throw. See [lines 180-192](https://github.com/MantleFramework/Mantle/blob/2.0-development/Mantle/NSValueTransformer+MTLPredefinedTransformerAdditions.m#L180-L192) and [114-123](https://github.com/MantleFramework/Mantle/blob/2.0-development/Mantle/NSValueTransformer+MTLPredefinedTransformerAdditions.m#L114-L123).

Shouldn't we just attempt the transformation in line 180 and returned the JSON dictionary transformer's error? Or we could provide more detail by returning the dictionary error via the `NSUnderlyingErrorKey` and detail which object in the array failed to transform.