### PR TITLE
Add support for file URLs in MTLURLValueTransformerName

### DIFF
--- a/Mantle/NSValueTransformer+MTLPredefinedTransformerAdditions.m
+++ b/Mantle/NSValueTransformer+MTLPredefinedTransformerAdditions.m
@@ -23,7 +23,7 @@ NSString * const MTLBooleanValueTransformerName = @"MTLBooleanValueTransformerNa
 		MTLValueTransformer *URLValueTransformer = [MTLValueTransformer
 			reversibleTransformerWithForwardBlock:^ id (NSString *str) {
 				if (![str isKindOfClass:NSString.class]) return nil;
-				return ([NSURL URLWithString:str] ?: [NSURL fileURLWithPath:str]);
+				return [NSURL URLWithString:str] ?: [NSURL fileURLWithPath:str];
 			}
 			reverseBlock:^ id (NSURL *URL) {
 				if (![URL isKindOfClass:NSURL.class]) return nil;

--- a/MantleTests/MTLPredefinedTransformerAdditionsSpec.m
+++ b/MantleTests/MTLPredefinedTransformerAdditionsSpec.m
@@ -25,6 +25,11 @@ it(@"should define a URL value transformer", ^{
 	expect([transformer transformedValue:URLString]).to.equal([NSURL URLWithString:URLString]);
 	expect([transformer reverseTransformedValue:[NSURL URLWithString:URLString]]).to.equal(URLString);
 
+	// Write temporary file for use in testing file URLs
+    NSURL *fileURL = [NSURL fileURLWithPath:[NSTemporaryDirectory() stringByAppendingPathComponent:@"file.txt"]];
+	expect([transformer transformedValue:fileURL.absoluteString]).to.equal(fileURL);
+	expect([transformer reverseTransformedValue:fileURL]).to.equal(fileURL.absoluteString);
+
 	expect([transformer transformedValue:nil]).to.beNil();
 	expect([transformer reverseTransformedValue:nil]).to.beNil();
 });


### PR DESCRIPTION
MTLURLValueTransformerName currently returns `nil` if a file URL is passed in. This also allows for file URLs to be used.
