### PR TITLE
Ability to specify a subset of properties for JSON representation.

### DIFF
--- a/Mantle/MTLJSONAdapter.h
+++ b/Mantle/MTLJSONAdapter.h
@@ -52,7 +52,7 @@
 // to abort parsing (e.g., if the data is invalid).
 + (Class)classForParsingJSONDictionary:(NSDictionary *)JSONDictionary;
 
-// Specifies the subset properties that will be included in the JSON
+// Specifies the subset of properties that will be included in the JSON
 // representation.
 //
 // Subclasses overriding this method should combine their values with those of

--- a/Mantle/MTLJSONAdapter.h
+++ b/Mantle/MTLJSONAdapter.h
@@ -52,6 +52,15 @@
 // to abort parsing (e.g., if the data is invalid).
 + (Class)classForParsingJSONDictionary:(NSDictionary *)JSONDictionary;
 
+// Specifies the subset properties that will be included in the JSON
+// representation.
+//
+// Subclasses overriding this method should combine their values with those of
+// `super`.
+//
+// Returns an array of property keys.
++ (NSArray *)propertyKeysForJSONRepresentation;
+
 @end
 
 // The domain for errors originating from MTLJSONAdapter.

--- a/Mantle/MTLJSONAdapter.m
+++ b/Mantle/MTLJSONAdapter.m
@@ -244,12 +244,23 @@ static NSString * const MTLJSONAdapterThrownExceptionErrorKey = @"MTLJSONAdapter
 
 	id JSONKeyPath = self.JSONKeyPathsByPropertyKey[key];
 	if ([JSONKeyPath isEqual:NSNull.null]) return nil;
-
+	
 	if (JSONKeyPath == nil) {
-		return key;
-	} else {
-		return JSONKeyPath;
+		JSONKeyPath = key;
 	}
+	
+	if ([self.modelClass respondsToSelector:@selector(propertyKeysForJSONRepresentation)]) {
+		NSSet *propertyKeys = [NSSet setWithArray:[self.modelClass propertyKeysForJSONRepresentation]];
+		
+		if ([propertyKeys containsObject:key]) {
+			return JSONKeyPath;
+		}
+		else {
+			return nil;
+		}
+	}
+	
+	return JSONKeyPath;
 }
 
 @end

--- a/MantleTests/MTLJSONAdapterSpec.m
+++ b/MantleTests/MTLJSONAdapterSpec.m
@@ -184,4 +184,19 @@ it(@"should return an error when no suitable model class is found", ^{
 	expect(error.code).to.equal(MTLJSONAdapterErrorNoClassFound);
 });
 
+it(@"should serialize a subset of properties to JSON", ^{
+	MTLPropertySubsetModel *model = [MTLPropertySubsetModel modelWithDictionary:@{
+		@"name": @"foobar",
+		@"count": @5
+	} error:NULL];
+	
+	MTLJSONAdapter *adapter = [[MTLJSONAdapter alloc] initWithModel:model];
+	
+	NSDictionary *JSONDictionary = @{
+		@"username": @"foobar"
+	};
+	
+	expect(adapter.JSONDictionary).to.equal(JSONDictionary);
+});
+
 SpecEnd

--- a/MantleTests/MTLTestModel.h
+++ b/MantleTests/MTLTestModel.h
@@ -55,3 +55,8 @@ extern const NSInteger MTLTestModelNameMissing;
 // Returns a default name of 'foobar' when validateName:error: is invoked
 @interface MTLSelfValidatingModel : MTLValidationModel
 @end
+
+// Specifies a subset of property keys that should be stored in JSON. The subset
+// only contains a single property: "name".
+@interface MTLPropertySubsetModel : MTLTestModel
+@end

--- a/MantleTests/MTLTestModel.m
+++ b/MantleTests/MTLTestModel.m
@@ -162,3 +162,11 @@ static NSUInteger modelVersion = 1;
 }
 
 @end
+
+@implementation MTLPropertySubsetModel
+
++ (NSArray *)propertyKeysForJSONRepresentation {
+	return @[ @"name" ];
+}
+
+@end


### PR DESCRIPTION
This pull request allows people to specify which properties are included in the JSON representation of their models on a per _class_ basis.

This is different from mapping a property to `NSNull.null` since it still allows the values of JSON key paths to be represented in model properties, but not the other way around.

It does not currently provide the ability to specify which keys should be included on a per _serialization_ basis (the use case being a HTTP PATCH request), but these changes could possibly be leveraged in providing support for that.

As discussed with @robb in #185 - I have a similar implementation which was achieved by extending `MTLJSONSerializing` and `MTLJSONAdapter`, and thought others might benefit from it being part of Mantle proper.

My use case was that I wanted to create a JSON representation of a newly created model so that I could send it in a POST request. Certain keys are managed by the server and therefore shouldn't have been present in a request. They were however expected to be present in a response, then their values assigned to properties of a model.