### PR TITLE
Transforms null boolean values into NO

### DIFF
--- a/Mantle/NSValueTransformer+MTLPredefinedTransformerAdditions.m
+++ b/Mantle/NSValueTransformer+MTLPredefinedTransformerAdditions.m
@@ -34,7 +34,7 @@ NSString * const MTLBooleanValueTransformerName = @"MTLBooleanValueTransformerNa
 
 		MTLValueTransformer *booleanValueTransformer = [MTLValueTransformer
 			reversibleTransformerWithBlock:^ id (NSNumber *boolean) {
-				if (![boolean isKindOfClass:NSNumber.class]) return nil;
+				if (![boolean isKindOfClass:NSNumber.class]) return (NSNumber *)kCFBooleanFalse;
 				return (NSNumber *)(boolean.boolValue ? kCFBooleanTrue : kCFBooleanFalse);
 			}];
 


### PR DESCRIPTION
without this, we were getting crashes on [NSObject(NSKeyValueCoding) setNilValueForKey] (inside of MTLValidateAndSetValue)