### PR TITLE
Ignore AppCode's .idea folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,7 @@ build/*
 xcuserdata
 profile
 *.moved-aside
+# AppCode etc.
+.idea/
 # Desktop Servies
 .DS_Store


### PR DESCRIPTION
Should save us from stuff like 9f25806d5f6aba584f0142d63bd9907f6b8aa3d2
