### PR TITLE
Add convenience method inserting arrays

### DIFF
--- a/Mantle/MTLManagedObjectAdapter.h
+++ b/Mantle/MTLManagedObjectAdapter.h
@@ -208,4 +208,14 @@ extern const NSInteger MTLManagedObjectAdapterErrorUnsupportedRelationshipClass;
 //           serialization or insertion.
 + (id)managedObjectFromModel:(MTLModel<MTLManagedObjectSerializing> *)model insertingIntoContext:(NSManagedObjectContext *)context error:(NSError **)error;
 
+// Serializes an array of MTLModel classes into an array of NSManagedObject.
+//
+// models  - An array of model object to serialize. This argument must not be nil.
+// context - The context into which to insert the created managed object. This
+//           argument must not be nil.
+// errors  - If not NULL, this may be set to an array of errors for each model
+//           that fails to insert.
+
++ (NSArray *)managedObjectsFromModels:(NSArray *)models insertingIntoContext:(NSManagedObjectContext *)context errors:(NSArray **)errors;
+
 @end

--- a/Mantle/MTLManagedObjectAdapter.m
+++ b/Mantle/MTLManagedObjectAdapter.m
@@ -548,6 +548,31 @@ static id performInContext(NSManagedObjectContext *context, id (^block)(void)) {
 	return [adapter managedObjectFromModel:model insertingIntoContext:context processedObjects:processedObjects error:error];
 }
 
++ (NSArray *)managedObjectsFromModels:(NSArray *)models insertingIntoContext:(NSManagedObjectContext *)context errors:(NSArray **)errors {
+	NSParameterAssert(models != nil);
+	NSParameterAssert(context != nil);
+
+	NSMutableArray *managedObjects = [NSMutableArray array];
+	NSMutableArray *insertErrors = [NSMutableArray array];
+
+	for (MTLModel<MTLManagedObjectSerializing> *model in models) {
+		NSError *managedObjectInsertError;
+		NSManagedObject *managedObject = [self managedObjectFromModel:model insertingIntoContext:context error:&managedObjectInsertError];
+
+		if (managedObject) {
+			[managedObjects addObject:managedObject];
+		} else {
+			[insertErrors addObject:managedObjectInsertError];
+		}
+	}
+
+	if (errors != NULL && [insertErrors count] > 0) {
+		*errors = [insertErrors copy];
+	}
+
+	return [managedObjects copy];
+}
+
 - (NSValueTransformer *)entityAttributeTransformerForKey:(NSString *)key {
 	NSParameterAssert(key != nil);
 

--- a/MantleTests/MTLManagedObjectAdapterSpec.m
+++ b/MantleTests/MTLManagedObjectAdapterSpec.m
@@ -314,6 +314,59 @@ describe(@"with a confined context", ^{
 			expect(updatedParentOne.string).to.equal(@"merged");
 		});
 	});
+
+	describe(@"+managedObjectsFromModels:insertingIntoContext:errors:", ^{
+		it(@"should insert multiple objects", ^{
+			NSArray *models = @[
+			    [MTLParentTestModel modelWithDictionary:@{
+					@"date": [NSDate date],
+					@"numberString": @"1234",
+					@"requiredString": @"foobar"
+				} error:NULL],
+				[MTLParentTestModel modelWithDictionary:@{
+					@"date": [NSDate date],
+					@"numberString": @"1234",
+					@"requiredString": @"foobar"
+				} error:NULL],
+				[MTLParentTestModel modelWithDictionary:@{
+					@"date": [NSDate date],
+					@"numberString": @"1234",
+					@"requiredString": @"foobar"
+				} error:NULL],
+			];
+
+			NSArray *errors;
+			NSArray *managedObjects = [MTLManagedObjectAdapter managedObjectsFromModels:models insertingIntoContext:context errors:&errors];
+
+			expect(errors).to.beNil();
+			expect([managedObjects count]).to.equal(3);
+		});
+
+		it(@"should output any failed insertations into the errors", ^{
+			NSArray *models = @[
+				[MTLParentTestModel modelWithDictionary:@{
+					@"date": [NSDate date],
+					@"numberString": @"1234",
+					@"requiredString": @"foobar",
+				} error:NULL],
+				[MTLParentTestModel modelWithDictionary:@{
+					@"date": [NSDate date],
+					@"numberString": @"1234",
+				} error:NULL],
+				[MTLParentTestModel modelWithDictionary:@{
+					@"date": [NSDate date],
+					@"numberString": @"1234",
+					@"requiredString": @"foobar",
+				} error:NULL],
+			];
+
+			NSArray *errors;
+			NSArray *managedObjects = [MTLManagedObjectAdapter managedObjectsFromModels:models insertingIntoContext:context errors:&errors];
+
+			expect([errors count]).to.equal(1);
+			expect([managedObjects count]).to.equal(2);
+		});
+	});
 });
 
 describe(@"with a main queue context", ^{


### PR DESCRIPTION
I'm not sure if I feel comfortable with this (`__out NSArray`?), so I'm sharing for consideration. Perhaps we can improve it. But basically, this adds the ability to insert an array of models into a managed object context. This allows some to fail, but still progressing with the import.
