### PR TITLE
Fix crash bug when parsing JSONArray

### DIFF
--- a/Mantle/MTLJSONAdapter.m
+++ b/Mantle/MTLJSONAdapter.m
@@ -63,7 +63,7 @@ static NSString * const MTLJSONAdapterThrownExceptionErrorKey = @"MTLJSONAdapter
 	for (NSDictionary *JSONDictionary in JSONArray){
 		MTLModel *model = [self modelOfClass:modelClass fromJSONDictionary:JSONDictionary error:error];
 
-		if (*error != NULL) return nil;
+		if (error != NULL && *error != NULL) return nil;
 		
 		[models addObject:model];
 	}


### PR DESCRIPTION
When calling modelsOfClass:fromJSONArray:error: with nil for error parameter, it will crash at *error != NULL check
