### PR TITLE
Exposed existing managed object fetching in MTLManagedObjectAdapter

### DIFF
--- a/Mantle/MTLManagedObjectAdapter.h
+++ b/Mantle/MTLManagedObjectAdapter.h
@@ -212,4 +212,18 @@ extern const NSInteger MTLManagedObjectAdapterErrorInvalidManagedObjectMapping;
 //           serialization or insertion.
 + (id)managedObjectFromModel:(MTLModel<MTLManagedObjectSerializing> *)model insertingIntoContext:(NSManagedObjectContext *)context error:(NSError **)error;
 
+// Attempts to retrieve an existing NSManagedObject for a given MTLModel object.
+//
+// By default, this method performs a fetch request with a predicate based on
+// model's `+propertyKeysForManagedObjectUniquing`.
+//
+// Subclasses may override this method to customize the adapter's behavior,
+// e.g. to provide some kind of caching.
+// You should not call this method directly.
+//
+// model   - The model object being serialized.
+// context - The context the returned managed object should belong to.
+// error   - If not NULL, this may be set to an error that occurs during fetch.
+- (id)fetchExistingManagedObjectForModel:(MTLModel<MTLManagedObjectSerializing> *)model inContext:(NSManagedObjectContext *)context error:(NSError **)error;
+
 @end


### PR DESCRIPTION
The problem described in #281 is kind of blocking me right now, let's do something :) 

I still think the best option would be exposing a method of `MTLManagedObjectAdapter` for subclassing. This approach is used in this PR. I don't think this should be part of `<MTLManagedObjectSerializing>` because fetching is not entity's business, more like a task for some kind of cache or storage.

Any thoughts?
