### PR TITLE
Change -initWithDictionary:error: to call super

### DIFF
--- a/Mantle/MTLModel.m
+++ b/Mantle/MTLModel.m
@@ -90,7 +90,7 @@ static BOOL MTLValidateAndSetValue(id obj, NSString *key, id value, BOOL forceUp
 }
 
 - (instancetype)initWithDictionary:(NSDictionary *)dictionary error:(NSError **)error {
-	self = [self init];
+	self = [super init];
 	if (self == nil) return nil;
 
 	for (NSString *key in dictionary) {


### PR DESCRIPTION
Call super's init instead of self's init (equivalent in Objective-C, but apparently confusing to Swift). Fixes (part of) #344
