### PR TITLE
Ordered relationship deserialization to NSOrderedSet vs NSMutableArray

### DIFF
--- a/Mantle/MTLManagedObjectAdapter.m
+++ b/Mantle/MTLManagedObjectAdapter.m
@@ -189,7 +189,7 @@ static id performInContext(NSManagedObjectContext *context, id (^block)(void)) {
 				});
 
 				if (models == nil) return NO;
-				if (![relationshipDescription isOrdered]) models = [NSSet setWithArray:models];
+				models = ([relationshipDescription isOrdered] ? [NSOrderedSet orderedSetWithArray:models] : [NSSet setWithArray:models]);
 
 				return setValueForKey(propertyKey, models);
 			} else {


### PR DESCRIPTION
Since Core Data ordered models are modeled as NSOrderedSet,

it seems reasonable for reverseBlock to expect an NSSet/NSOrderedSet in the transformer function instead of NSSet/NSMutableArray

```
+ (instancetype)reversibleTransformerWithForwardBlock:(MTLValueTransformerBlock)forwardBlock
                                         reverseBlock:(MTLValueTransformerBlock)reverseBlock
```

It's currently returning an NSMutableArray for ordered relationships - is there a reason for this?
