### PR TITLE
Implemented batch fetching for NSManagedObject uniquing

### DIFF
--- a/Mantle/MTLManagedObjectAdapter.h
+++ b/Mantle/MTLManagedObjectAdapter.h
@@ -203,6 +203,19 @@ extern const NSInteger MTLManagedObjectAdapterErrorInvalidManagedObjectMapping;
 // occurred.
 + (id)modelOfClass:(Class)modelClass fromManagedObject:(NSManagedObject *)managedObject error:(NSError **)error;
 
+// Attempts to deserialize an array of NSManagedObjects into a MTLModel objects.
+//
+// modelClass    -  The MTLModel subclass to return. This class must conform to
+//                  <MTLManagedObjectSerializing>. This argument must not be nil.
+// managedObjects - The managed objects to deserialize. If this argument is nil,
+//                  the method returns nil.
+// error          - If not NULL, this may be set to an error that occurs during
+//                  deserialization or initializing an instance of `modelClass`.
+//
+// Returns an array of `modelClass` upon success, or nil if an error
+// occurred.
++ (NSArray *)modelsOfClass:(Class)modelClass fromManagedObjects:(NSArray *)managedObjects error:(NSError **)error;
+
 // Serializes a MTLModel into an NSManagedObject.
 //
 // model   - The model object to serialize. This argument must not be nil.
@@ -211,5 +224,14 @@ extern const NSInteger MTLManagedObjectAdapterErrorInvalidManagedObjectMapping;
 // error   - If not NULL, this may be set to an error that occurs during
 //           serialization or insertion.
 + (id)managedObjectFromModel:(MTLModel<MTLManagedObjectSerializing> *)model insertingIntoContext:(NSManagedObjectContext *)context error:(NSError **)error;
+
+// Serializes an array of MTLModel objects into an array of NSManagedObjects.
+//
+// models  - The array to serialize. This argument must not be nil.
+// context - The context into which to insert the created managed objects. This
+//           argument must not be nil.
+// error   - If not NULL, this may be set to an error that occurs during
+//           serialization or insertion.
++ (NSArray *)managedObjectsFromModels:(NSArray *)models insertingIntoContext:(NSManagedObjectContext *)context error:(NSError **)error;
 
 @end

--- a/Mantle/MTLManagedObjectAdapter.m
+++ b/Mantle/MTLManagedObjectAdapter.m
@@ -836,6 +836,8 @@ static id performInContext(NSManagedObjectContext *context, id (^block)(void)) {
 				currentTokenIndex++;
 			}
 		} while (comparisonResult == NSOrderedDescending && currentTokenIndex < uniquingTokens.count);
+		
+		if (currentTokenIndex >= uniquingTokens.count) break;
 	}
 
 	return YES;

--- a/Mantle/MTLManagedObjectAdapter.m
+++ b/Mantle/MTLManagedObjectAdapter.m
@@ -66,20 +66,20 @@ static id performInContext(NSManagedObjectContext *context, id (^block)(void)) {
 	NSParameterAssert(uniquingValues != nil);
 	
 	NSArray *sortedKeys = [[uniquingValues allKeys] sortedArrayUsingSelector:@selector(compare:)];
-    NSArray *values = [uniquingValues objectsForKeys:sortedKeys notFoundMarker:NSNull.null];
+	NSArray *values = [uniquingValues objectsForKeys:sortedKeys notFoundMarker:NSNull.null];
 	
 	NSMutableDictionary *currentDictionary = [self nestedDictionaryForModelClass:model.class];
-    
-    for (id value in values) {
-        if (value != values.lastObject) {
-            NSMutableDictionary *valueDictionary = currentDictionary[value];
-            if (valueDictionary == nil) {
-                valueDictionary = [NSMutableDictionary dictionary];
-                currentDictionary[value] = valueDictionary;
-            }
-            currentDictionary = valueDictionary;
-        }
-    }
+	
+	for (id value in values) {
+		if (value != values.lastObject) {
+			NSMutableDictionary *valueDictionary = currentDictionary[value];
+			if (valueDictionary == nil) {
+				valueDictionary = [NSMutableDictionary dictionary];
+				currentDictionary[value] = valueDictionary;
+			}
+			currentDictionary = valueDictionary;
+		}
+	}
 	
 	NSMutableArray *models = currentDictionary[values.lastObject];
 	
@@ -108,19 +108,19 @@ static id performInContext(NSManagedObjectContext *context, id (^block)(void)) {
 	NSParameterAssert(modelClass != Nil);
 	
 	NSArray *sortedKeys = [[uniquingValues allKeys] sortedArrayUsingSelector:@selector(compare:)];
-    NSArray *values = [uniquingValues objectsForKeys:sortedKeys notFoundMarker:NSNull.null];
-    
-    NSMutableDictionary *currentDictionary = [self nestedDictionaryForModelClass:modelClass];
+	NSArray *values = [uniquingValues objectsForKeys:sortedKeys notFoundMarker:NSNull.null];
 	
-    for (id value in values) {
-        if (value != values.lastObject) {
-            NSMutableDictionary *valueDictionary = currentDictionary[value];
-            if (valueDictionary == nil) {
-                return nil;
-            }
-            currentDictionary = valueDictionary;
-        }
-    }
+	NSMutableDictionary *currentDictionary = [self nestedDictionaryForModelClass:modelClass];
+	
+	for (id value in values) {
+		if (value != values.lastObject) {
+			NSMutableDictionary *valueDictionary = currentDictionary[value];
+			if (valueDictionary == nil) {
+				return nil;
+			}
+			currentDictionary = valueDictionary;
+		}
+	}
 	
 	NSMutableArray *mutableModels = currentDictionary[values.lastObject];
 	return [mutableModels copy];
@@ -240,10 +240,10 @@ static id performInContext(NSManagedObjectContext *context, id (^block)(void)) {
 // Looks up the NSValueTransformer that should be used for any attribute that
 // corresponds the given property key and MTLModel subclass.
 //
-// key        - The property key to transform from or to. This argument must not
-//              be nil.
+// key		- The property key to transform from or to. This argument must not
+//			  be nil.
 // modelClass - The MTLModel subclass being serialized. This class must conform
-//              to <MTLManagedObjectSerializing>. This argument must not be nil.
+//			  to <MTLManagedObjectSerializing>. This argument must not be nil.
 //
 // Returns a transformer to use, or nil to not transform the property.
 + (NSValueTransformer *)entityAttributeTransformerForKey:(NSString *)key forModelClass:(Class)modelClass;
@@ -260,7 +260,7 @@ static id performInContext(NSManagedObjectContext *context, id (^block)(void)) {
 // given MTLModel subclass. Omitted property keys are excluded.
 //
 // modelClass - The MTLModel subclass being serialized. This class must conform
-//              to <MTLManagedObjectSerializing>. This argument must not be nil.
+//			  to <MTLManagedObjectSerializing>. This argument must not be nil.
 //
 // Returns a dictionary containing property keys as keys and corresponding
 // managed objects keys as values.
@@ -509,7 +509,7 @@ static id performInContext(NSManagedObjectContext *context, id (^block)(void)) {
 	NSAssert(entityDescriptionClass != nil, @"CoreData.framework must be linked to use MTLManagedObjectAdapter");
 
 	// Check if we already have a corresponding existing managed object.
-    MTLManagedObjectHolder *managedObjectHolder = (__bridge MTLManagedObjectHolder *)CFDictionaryGetValue(existingObjects, (__bridge void *)model);
+	MTLManagedObjectHolder *managedObjectHolder = (__bridge MTLManagedObjectHolder *)CFDictionaryGetValue(existingObjects, (__bridge void *)model);
 	__block NSManagedObject *managedObject = managedObjectHolder.managedObject;
 
 	if (managedObject == nil) {
@@ -542,8 +542,8 @@ static id performInContext(NSManagedObjectContext *context, id (^block)(void)) {
 	// Pre-emptively consider this object processed, so that we don't get into
 	// any cycles when processing its relationships.
 	CFDictionaryAddValue(processedObjects, (__bridge void *)model, (__bridge void *)managedObject);
-    
-    managedObjectHolder.managedObject = managedObject;
+	
+	managedObjectHolder.managedObject = managedObject;
 
 	NSDictionary *dictionaryValue = model.dictionaryValue;
 	NSDictionary *managedObjectProperties = managedObject.entity.propertiesByName;
@@ -696,11 +696,11 @@ static id performInContext(NSManagedObjectContext *context, id (^block)(void)) {
 + (NSArray *)managedObjectsFromModels:(NSArray *)models insertingIntoContext:(NSManagedObjectContext *)context error:(NSError **)error {
 	MTLUniquingValuesStorage *uniquingValuesStorage = [[MTLUniquingValuesStorage alloc] init];
 	
-    // Compare MTLModel keys using pointer equality, not -isEqual:.
+	// Compare MTLModel keys using pointer equality, not -isEqual:.
 	CFSetCallBacks setCallbacks = kCFTypeSetCallBacks;
 	setCallbacks.equal = NULL;
-    
-    CFDictionaryKeyCallBacks keyCallbacks = kCFTypeDictionaryKeyCallBacks;
+	
+	CFDictionaryKeyCallBacks keyCallbacks = kCFTypeDictionaryKeyCallBacks;
 	keyCallbacks.equal = NULL;
 
 	
@@ -765,7 +765,7 @@ static id performInContext(NSManagedObjectContext *context, id (^block)(void)) {
 	if (CFSetContainsValue(processedObjects, (__bridge void *)model)) return;
 	CFSetAddValue(processedObjects, (__bridge void *)model);
 		
-    NSDictionary *uniquingValues = [self uniquingValuesForModel:model];
+	NSDictionary *uniquingValues = [self uniquingValuesForModel:model];
 	if (uniquingValues != nil) {
 		[uniquingValuesStorage addModel:model withUniquingValues:uniquingValues];
 	}
@@ -837,25 +837,25 @@ static id performInContext(NSManagedObjectContext *context, id (^block)(void)) {
 	NSSet *propertyKeys = [modelClass propertyKeysForManagedObjectUniquing];
 	NSDictionary *managedObjectKeysByPropertyKey = [self managedObjectKeysByPropertyKeyForModelClass:modelClass];
 	NSArray *managedObjectKeys = [managedObjectKeysByPropertyKey objectsForKeys:[propertyKeys allObjects] notFoundMarker:NSNull.null];
-    
-    NSArray *uniquingValuesArray = [uniquingValuesStorage uniquingValuesForModelClass:modelClass];
+	
+	NSArray *uniquingValuesArray = [uniquingValuesStorage uniquingValuesForModelClass:modelClass];
 	
 	NSMutableArray *subpredicates = [NSMutableArray arrayWithCapacity:propertyKeys.count];
 	
 	for (NSString *managedObjectKey in managedObjectKeys) {
-        NSMutableArray *managedObjectValues = [NSMutableArray arrayWithCapacity:uniquingValuesArray.count];
-        
-        for (NSDictionary *uniquingValues in uniquingValuesArray) {
-            [managedObjectValues addObject:uniquingValues[managedObjectKey]];
-        }
-        
-        NSPredicate *subpredicate = [NSPredicate predicateWithFormat:@"%K in %@", managedObjectKey, [NSSet setWithArray:managedObjectValues]];
-        [subpredicates addObject:subpredicate];
-    }
-    
-    NSPredicate *uniquingPredicate = [NSCompoundPredicate andPredicateWithSubpredicates:subpredicates];
+		NSMutableArray *managedObjectValues = [NSMutableArray arrayWithCapacity:uniquingValuesArray.count];
+		
+		for (NSDictionary *uniquingValues in uniquingValuesArray) {
+			[managedObjectValues addObject:uniquingValues[managedObjectKey]];
+		}
+		
+		NSPredicate *subpredicate = [NSPredicate predicateWithFormat:@"%K in %@", managedObjectKey, [NSSet setWithArray:managedObjectValues]];
+		[subpredicates addObject:subpredicate];
+	}
+	
+	NSPredicate *uniquingPredicate = [NSCompoundPredicate andPredicateWithSubpredicates:subpredicates];
 
-    
+	
 	NSString *entityName = [modelClass managedObjectEntityName];
 	NSAssert(entityName != nil, @"%@ returned a nil +managedObjectEntityName", modelClass);
 	
@@ -898,18 +898,18 @@ static id performInContext(NSManagedObjectContext *context, id (^block)(void)) {
 		*error = fetchRequestError;
 		return NO;
 	}
-    
-    
-    for (NSDictionary *uniquingValues in uniquingValuesArray) {
-        MTLManagedObjectHolder *managedObjectHolder = [[MTLManagedObjectHolder alloc] init];
+	
+	
+	for (NSDictionary *uniquingValues in uniquingValuesArray) {
+		MTLManagedObjectHolder *managedObjectHolder = [[MTLManagedObjectHolder alloc] init];
 		NSArray *models = [uniquingValuesStorage modelsForUniquingValues:uniquingValues forModelClass:modelClass];
-        for (id model in models) {
-            CFDictionarySetValue(managedObjectHoldersByModel, (__bridge void *)model, (__bridge void *)managedObjectHolder);
-        }
-    }
-    
+		for (id model in models) {
+			CFDictionarySetValue(managedObjectHoldersByModel, (__bridge void *)model, (__bridge void *)managedObjectHolder);
+		}
+	}
+	
 	for (NSManagedObject *managedObject in managedObjects) {
-        NSMutableDictionary *uniquingValues = [[NSMutableDictionary alloc] initWithCapacity:propertyKeys.count];
+		NSMutableDictionary *uniquingValues = [[NSMutableDictionary alloc] initWithCapacity:propertyKeys.count];
 		
 		for (NSString *propertyKey in propertyKeys) {
 			NSString *managedObjectKey = managedObjectKeysByPropertyKey[propertyKey];
@@ -919,13 +919,13 @@ static id performInContext(NSManagedObjectContext *context, id (^block)(void)) {
 			
 			uniquingValues[managedObjectKey] = value;
 		}
-        
-        NSArray *models = [uniquingValuesStorage modelsForUniquingValues:uniquingValues forModelClass:modelClass];
-        
-        if (models != nil) {
-            MTLManagedObjectHolder *managedObjectHolder = (__bridge MTLManagedObjectHolder *)CFDictionaryGetValue(managedObjectHoldersByModel, (__bridge void *)models.mtl_firstObject);
-            managedObjectHolder.managedObject = managedObject;
-        }
+		
+		NSArray *models = [uniquingValuesStorage modelsForUniquingValues:uniquingValues forModelClass:modelClass];
+		
+		if (models != nil) {
+			MTLManagedObjectHolder *managedObjectHolder = (__bridge MTLManagedObjectHolder *)CFDictionaryGetValue(managedObjectHoldersByModel, (__bridge void *)models.mtl_firstObject);
+			managedObjectHolder.managedObject = managedObject;
+		}
 	}
 
 	return YES;

--- a/MantleTests/MTLManagedObjectAdapterSpec.m
+++ b/MantleTests/MTLManagedObjectAdapterSpec.m
@@ -401,11 +401,13 @@ describe(@"with a confined context", ^{
 
 		beforeEach(^{
 			parentModel1 = [MTLParentTestModel modelWithDictionary:@{
+				@"numberString": @"11",
 				@"requiredString": @"foo"
 			} error:NULL];
 			expect(parentModel1).notTo.beNil();
 			
 			parentModel2 = [MTLParentTestModel modelWithDictionary:@{
+				@"numberString": @"22",
 				@"requiredString": @"bar"
 			} error:NULL];
 			expect(parentModel2).notTo.beNil();


### PR DESCRIPTION
As discussed in #324, there is a big performance hit when converting a big number of `MTLModel`s to `NSManagedObjects`s, because an individual fetch request is made whenever a unique managed object is expected. 

This PR takes an approach of batching these individual fetch requests into bigger ones. This allows for a great performance improvement (over a magnitude) compared to the current approach. 

First, an additional pass through the model hierarchy is performed before an actual serialization. During this pass, all uniquing key-value pairs are being collected per model class. These values are then used to compile fetch requests. Models are then bound to fetched managed objects, so they can be used during the main serialization pass.

`MTLManagedObjectAdapter` now has two new methods accepting collections, similar to `MTLJSONAdapter`. However, in this case it's not just a mere conveniency, but also a big source of optimization.

I've added some basic tests for this stuff, however I intend to add more for complex cases such as multiple uniquing keys. 

Looking forward to hear from you :)