### PR TITLE
Store managed object relationships as arrays

### DIFF
--- a/Mantle/MTLManagedObjectAdapter.m
+++ b/Mantle/MTLManagedObjectAdapter.m
@@ -174,7 +174,7 @@ static id performInContext(NSManagedObjectContext *context, id (^block)(void)) {
 			}
 
 			if ([relationshipDescription isToMany]) {
-				id models = performInContext(context, ^ id {
+				NSArray *models = performInContext(context, ^ id {
 					id relationshipCollection = [managedObject valueForKey:managedObjectKey];
 					NSMutableArray *models = [NSMutableArray arrayWithCapacity:[relationshipCollection count]];
 
@@ -185,11 +185,10 @@ static id performInContext(NSManagedObjectContext *context, id (^block)(void)) {
 						[models addObject:model];
 					}
 
-					return models;
+					return [models copy];
 				});
 
 				if (models == nil) return NO;
-				if (![relationshipDescription isOrdered]) models = [NSSet setWithArray:models];
 
 				return setValueForKey(propertyKey, models);
 			} else {

--- a/MantleTests/MTLCoreDataTestModels.h
+++ b/MantleTests/MTLCoreDataTestModels.h
@@ -19,7 +19,7 @@
 @property (nonatomic, copy) NSString *requiredString;
 
 @property (nonatomic, copy) NSArray *orderedChildren;
-@property (nonatomic, copy) NSSet *unorderedChildren;
+@property (nonatomic, copy) NSArray *unorderedChildren;
 
 @end
 

--- a/MantleTests/MTLManagedObjectAdapterSpec.m
+++ b/MantleTests/MTLManagedObjectAdapterSpec.m
@@ -117,6 +117,18 @@ describe(@"with a confined context", ^{
 				expect(child.parent2).to.beNil();
 			}
 		});
+
+		it(@"should convert an NSSet containing unordered children to an array", ^{
+			NSError *error;
+			MTLParentTestModel *parentModel = [MTLManagedObjectAdapter modelOfClass:MTLParentTestModel.class fromManagedObject:parent error:&error];
+			expect(parentModel.orderedChildren).to.beKindOf([NSArray class]);
+		});
+
+		it(@"should convert an NSOrderedSet containing ordered children to an array", ^{
+			NSError *error;
+			MTLParentTestModel *parentModel = [MTLManagedObjectAdapter modelOfClass:MTLParentTestModel.class fromManagedObject:parent error:&error];
+			expect(parentModel.unorderedChildren).to.beKindOf([NSArray class]);
+		});
 	});
 
 	describe(@"+managedObjectFromModel:insertingIntoContext:error:", ^{
@@ -131,7 +143,7 @@ describe(@"with a confined context", ^{
 			expect(parentModel).notTo.beNil();
 
 			NSMutableArray *orderedChildren = [NSMutableArray array];
-			NSMutableSet *unorderedChildren = [NSMutableSet set];
+			NSMutableArray *unorderedChildren = [NSMutableArray array];
 
 			for (NSUInteger i = 0; i < 3; i++) {
 				MTLChildTestModel *child = [MTLChildTestModel modelWithDictionary:@{
@@ -279,7 +291,7 @@ describe(@"with a confined context", ^{
 			MTLParentTestModel *parentModelCopy = [parentModel copy];
 			[[parentModelCopy mutableOrderedSetValueForKey:@"orderedChildren"] removeObjectAtIndex:1];
 
-			MTLChildTestModel *childToDeleteModel = [parentModelCopy.unorderedChildren anyObject];
+			MTLChildTestModel *childToDeleteModel = [parentModelCopy.unorderedChildren firstObject];
 			[[parentModelCopy mutableSetValueForKey:@"unorderedChildren"] removeObject:childToDeleteModel];
 
 			MTLParent *parentTwo = [MTLManagedObjectAdapter managedObjectFromModel:parentModelCopy insertingIntoContext:context error:&error];


### PR DESCRIPTION
Since models in Core Data are uniqued by the ObjectID. You can have multiple object's with the same contents, but different managed object IDs. However -[MTLModel isEqual:] method will say that two objects, with the same contents are the same (because they are in this context). When you convert these different managed object's into MTLModels and then place them in an NSSet, it will treat them as equal and only show one item.

Closes #352