### PR TITLE
MTLValueTransformer improvements for inheritance

### DIFF
--- a/Mantle/MTLValueTransformer.h
+++ b/Mantle/MTLValueTransformer.h
@@ -26,4 +26,18 @@ typedef id (^MTLValueTransformerBlock)(id);
 // Returns a transformer which transforms values using the given blocks.
 + (instancetype)reversibleTransformerWithForwardBlock:(MTLValueTransformerBlock)forwardBlock reverseBlock:(MTLValueTransformerBlock)reverseBlock;
 
+- (id)initWithForwardBlock:(MTLValueTransformerBlock)forwardBlock
+              reverseBlock:(MTLValueTransformerBlock)reverseBlock;
+
+@end
+
+//
+// Any MTLValueTransformer supporting reverse transformation. Necessary because
+// +allowsReverseTransformation is a class method.
+//
+@interface MTLReversibleValueTransformer : MTLValueTransformer
+
+- (id)initWithForwardBlock:(MTLValueTransformerBlock)forwardBlock
+              reverseBlock:(MTLValueTransformerBlock)reverseBlock;
+
 @end

--- a/Mantle/MTLValueTransformer.m
+++ b/Mantle/MTLValueTransformer.m
@@ -8,13 +8,6 @@
 
 #import "MTLValueTransformer.h"
 
-//
-// Any MTLValueTransformer supporting reverse transformation. Necessary because
-// +allowsReverseTransformation is a class method.
-//
-@interface MTLReversibleValueTransformer : MTLValueTransformer
-@end
-
 @interface MTLValueTransformer ()
 
 @property (nonatomic, copy, readonly) MTLValueTransformerBlock forwardBlock;


### PR DESCRIPTION
- Moved MTLReversibleValueTransformer interface declaration to MTLValueTransformer.h
- Declared initWithForwardBlock:reverseBlock: in interface to make it accessible
