### PR TITLE
Only build the tests when testing.

### DIFF
--- a/Mantle.xcodeproj/xcshareddata/xcschemes/Mantle iOS.xcscheme
+++ b/Mantle.xcodeproj/xcshareddata/xcschemes/Mantle iOS.xcscheme
@@ -22,10 +22,10 @@
          </BuildActionEntry>
          <BuildActionEntry
             buildForTesting = "YES"
-            buildForRunning = "YES"
+            buildForRunning = "NO"
             buildForProfiling = "NO"
             buildForArchiving = "NO"
-            buildForAnalyzing = "YES">
+            buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "D0E9C36019F6DB38000D427D"


### PR DESCRIPTION
The iOS tests are being built all the time, and this is [causing some headaches](https://github.com/Carthage/Carthage/issues/201). This brings the iOS scheme into line with the Mac one.
