### PR TITLE
Pacify Xcode

### DIFF
--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,3 +1,3 @@
-github "jspahrsummers/xcconfigs" >= 0.7
+github "jspahrsummers/xcconfigs" >= 0.7.1
 github "Quick/Quick" ~> 0.2
 github "Quick/Nimble" ~> 0.2

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
 github "Quick/Nimble" "v0.2.0"
 github "Quick/Quick" "v0.2.2"
-github "jspahrsummers/xcconfigs" "0.7"
+github "jspahrsummers/xcconfigs" "0.7.1"

--- a/Mantle.xcodeproj/project.pbxproj
+++ b/Mantle.xcodeproj/project.pbxproj
@@ -639,7 +639,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastTestingUpgradeCheck = 0510;
-				LastUpgradeCheck = 0610;
+				LastUpgradeCheck = 0620;
 				ORGANIZATIONNAME = GitHub;
 				TargetAttributes = {
 					D0E9C35619F6DB38000D427D = {
@@ -816,6 +816,7 @@
 			buildSettings = {
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				MACOSX_DEPLOYMENT_TARGET = 10.8;
+				ONLY_ACTIVE_ARCH = YES;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;

--- a/Mantle.xcodeproj/xcshareddata/xcschemes/Mantle Mac.xcscheme
+++ b/Mantle.xcodeproj/xcshareddata/xcschemes/Mantle Mac.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0610"
+   LastUpgradeVersion = "0620"
    version = "2.0">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Mantle.xcodeproj/xcshareddata/xcschemes/Mantle iOS.xcscheme
+++ b/Mantle.xcodeproj/xcshareddata/xcschemes/Mantle iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0610"
+   LastUpgradeVersion = "0620"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"


### PR DESCRIPTION
For https://github.com/jspahrsummers/xcconfigs/pull/32.

And I know what you’re thinking, “But `ONLY_ACTIVE_ARCH` is already in the xcconfig!” Yes. Well. Xcode.