### PR TITLE
MTLManagedObjectAdapter ordered sets on relationships

### DIFF
--- a/Mantle/MTLManagedObjectAdapter.m
+++ b/Mantle/MTLManagedObjectAdapter.m
@@ -189,7 +189,10 @@ static id performInContext(NSManagedObjectContext *context, id (^block)(void)) {
 				});
 
 				if (models == nil) return NO;
-				if (![relationshipDescription isOrdered]) models = [NSSet setWithArray:models];
+				if ([relationshipDescription isOrdered]) 
+					models = [NSOrderedSet orderedSetWithArray:models];
+				else
+					models = [NSSet setWithArray:models];
 
 				return setValueForKey(propertyKey, models);
 			} else {


### PR DESCRIPTION
	- Make the return class cluster mapped properly when the relationship is ToMany or not with NSOrderedSet or NSSet.

Actually when in coreData model it's checked a relationship as "ordered". The adapter returns a NSMutableArray instead NSOrderedSet.