### PR TITLE
Uniquing capability for MTLModels

### DIFF
--- a/Mantle/MTLManagedObjectAdapter.m
+++ b/Mantle/MTLManagedObjectAdapter.m
@@ -189,7 +189,10 @@ static id performInContext(NSManagedObjectContext *context, id (^block)(void)) {
 				});
 
 				if (models == nil) return NO;
-				if (![relationshipDescription isOrdered]) models = [NSSet setWithArray:models];
+				if ([relationshipDescription isOrdered]) 
+					models = [NSOrderedSet orderedSetWithArray:models];
+				else
+					models = [NSSet setWithArray:models];
 
 				return setValueForKey(propertyKey, models);
 			} else {

--- a/Mantle/MTLModel.h
+++ b/Mantle/MTLModel.h
@@ -68,7 +68,11 @@
 // `model` must be an instance of the receiver's class or a subclass thereof.
 - (void)mergeValuesForKeysFromModel:(MTLModel *)model;
 
-
+// This flag will be used by Mantle to give you the ability to have two different
+// `models` with the same property values.
+//
+// By default is NO. But if for domain restriction of your app is necessary to have different
+// `models` with identical values of its properties, please return YES in your models.
 - (BOOL)shouldBeIdentifiedUniquing;
 
 // Compares the receiver with another object for equality.

--- a/Mantle/MTLModel.h
+++ b/Mantle/MTLModel.h
@@ -68,6 +68,9 @@
 // `model` must be an instance of the receiver's class or a subclass thereof.
 - (void)mergeValuesForKeysFromModel:(MTLModel *)model;
 
+
+- (BOOL)shouldBeIdentifiedUniquing;
+
 // Compares the receiver with another object for equality.
 //
 // The default implementation is equivalent to comparing both models'

--- a/Mantle/MTLModel.m
+++ b/Mantle/MTLModel.m
@@ -223,7 +223,10 @@ NS_INLINE NSString * MTLGetObjectUniqueIdentifier (MTLModel *objMTLmodel) {
 #pragma mark NSCopying
 
 - (instancetype)copyWithZone:(NSZone *)zone {
-	return [[self.class allocWithZone:zone] initWithDictionary:self.dictionaryValue error:NULL];
+	MTLModel *copiedModel = [[self.class allocWithZone:zone] initWithDictionary:self.dictionaryValue error:NULL];
+	copiedModel->_mtlUniqueIdentifier = self.mtlUniqueIdentifier;
+	
+	return copiedModel;
 }
 
 #pragma mark NSObject
@@ -251,6 +254,9 @@ NS_INLINE NSString * MTLGetObjectUniqueIdentifier (MTLModel *objMTLmodel) {
 	if (self == model) return YES;
 	if (![model isMemberOfClass:self.class]) return NO;
 
+	if ([self shouldBeIdentifiedUniquing]) 
+		return [self.mtlUniqueIdentifier isEqualToString:model.mtlUniqueIdentifier];	
+	
 	for (NSString *key in self.class.propertyKeys) {
 		id selfValue = [self valueForKey:key];
 		id modelValue = [model valueForKey:key];


### PR DESCRIPTION
Approach to give Mantle the capability of distinct `MTLModel` with the same properties if it's needed by *domain restrictions*

With these approach we can have the next:

```objective-c
MTLModel *modelA = [MTLModel alloc] init];
modelA.propertyC = @"foo";
modelA.propertyD = @"fooBar";

MTLModel *modelB = [MTLModel alloc] init];
modelB.propertyC = @"foo";
modelB.propertyD = @"fooBar";`

NSLog(@"modelA and modelB are not equals");
```

But when we check if that models are equal will return **NO**

We just need to override the method `- (BOOL)shouldBeIdentifiedUniquing;` in our desired models and the magic happen.

```objective-c
- (BOOL)shouldBeIdentifiedUniquing
{
    return YES;
}
```