### PR TITLE
Updated README for iOS installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -478,8 +478,7 @@ To add Mantle to your application:
 
  1. Add the Mantle repository as a submodule of your application's repository.
  1. Run `script/bootstrap` from within the Mantle folder.
- 1. Drag and drop `Mantle.xcodeproj` into your application's Xcode project or
-    workspace.
+ 1. Drag and drop `Mantle.xcodeproj` into your application's Xcode project. Unfortunately, an [Xcode bug](http://www.openradar.appspot.com/19676555) means you should probably not add it to a workspace.
  1. On the "General" tab of your application target, add `Mantle.framework` to the "Embedded Binaries".
 
 [Carthage](https://github.com/Carthage/Carthage) users can simply add Mantle to their `Cartfile`:

--- a/README.md
+++ b/README.md
@@ -480,12 +480,11 @@ To add Mantle to your application:
  1. Run `script/bootstrap` from within the Mantle folder.
  1. Drag and drop `Mantle.xcodeproj` into your application's Xcode project or
     workspace.
- 1. On the "Build Phases" tab of your application target, add Mantle to the
-    "Link Binary With Libraries" phase.
-    * **On iOS**, add `libMantle.a`.
-    * **On OS X**, add `Mantle.framework`. Mantle must also be added to any
-      "Copy Frameworks" build phase. If you don't already have one, simply add a
-      "Copy Files" build phase and target the "Frameworks" destination.
+ 1. On the "General" tab of your application target, link Mantle.
+    * **On iOS**, add `Mantle.framework` to the "Embedded Binaries" build phase.
+    * **On OS X**, add `Mantle.framework` to the "Linked Frameworks and Libraries" build phase. 
+    Mantle must also be added to any "Copy Frameworks" build phase. If you don't already have 
+    one, simply add a "Copy Files" build phase and target the "Frameworks" destination.
  1. Add `"$(BUILD_ROOT)/../IntermediateBuildFilesPath/UninstalledProducts/include" $(inherited)`
     to the "Header Search Paths" build setting (this is only
     necessary for archive builds, but it has no negative effect otherwise).

--- a/README.md
+++ b/README.md
@@ -489,6 +489,11 @@ To add Mantle to your application:
     to add the appropriate Mantle target to the "Target Dependencies" of your
     application.
 
+[Carthage](https://github.com/Carthage/Carthage) users can simply add Mantle to their `Cartfile`:
+```
+github "Mantle/Mantle"
+```
+
 If you would prefer to use [CocoaPods](http://cocoapods.org), there are some
 [Mantle podspecs](https://github.com/CocoaPods/Specs/tree/master/Specs/Mantle) that
 have been generously contributed by third parties.

--- a/README.md
+++ b/README.md
@@ -481,13 +481,6 @@ To add Mantle to your application:
  1. Drag and drop `Mantle.xcodeproj` into your application's Xcode project or
     workspace.
  1. On the "General" tab of your application target, add `Mantle.framework` to the "Embedded Binaries".
- 1. Add `"$(BUILD_ROOT)/../IntermediateBuildFilesPath/UninstalledProducts/include" $(inherited)`
-    to the "Header Search Paths" build setting (this is only
-    necessary for archive builds, but it has no negative effect otherwise).
- 1. **For iOS targets**, add `-ObjC` to the "Other Linker Flags" build setting.
- 1. **If you added Mantle to a project (not a workspace)**, you will also need
-    to add the appropriate Mantle target to the "Target Dependencies" of your
-    application.
 
 [Carthage](https://github.com/Carthage/Carthage) users can simply add Mantle to their `Cartfile`:
 ```

--- a/README.md
+++ b/README.md
@@ -480,11 +480,7 @@ To add Mantle to your application:
  1. Run `script/bootstrap` from within the Mantle folder.
  1. Drag and drop `Mantle.xcodeproj` into your application's Xcode project or
     workspace.
- 1. On the "General" tab of your application target, link Mantle.
-    * **On iOS**, add `Mantle.framework` to the "Embedded Binaries" build phase.
-    * **On OS X**, add `Mantle.framework` to the "Linked Frameworks and Libraries" build phase. 
-    Mantle must also be added to any "Copy Frameworks" build phase. If you don't already have 
-    one, simply add a "Copy Files" build phase and target the "Frameworks" destination.
+ 1. On the "General" tab of your application target, add `Mantle.framework` to the "Embedded Binaries".
  1. Add `"$(BUILD_ROOT)/../IntermediateBuildFilesPath/UninstalledProducts/include" $(inherited)`
     to the "Header Search Paths" build setting (this is only
     necessary for archive builds, but it has no negative effect otherwise).


### PR DESCRIPTION
Implements #480 

It seems that in Xcode 8.3, at least, adding the binary to the "Embedded Frameworks" build phase does all that's required. Runs fine on device.

We don't mention Carthage as an installation option, but we have the badge. Think it's worth a mention above CocoaPods?