### PR TITLE
Changed name of class parameter to modelClass

### DIFF
--- a/Mantle/NSDictionary+MTLMappingAdditions.h
+++ b/Mantle/NSDictionary+MTLMappingAdditions.h
@@ -16,6 +16,6 @@
 ///
 /// Returns a dictionary that maps all properties of the given class to
 /// themselves.
-+ (NSDictionary *)mtl_identityPropertyMapWithModel:(Class)class;
++ (NSDictionary *)mtl_identityPropertyMapWithModel:(Class)modelClass;
 
 @end

--- a/Mantle/NSDictionary+MTLMappingAdditions.m
+++ b/Mantle/NSDictionary+MTLMappingAdditions.m
@@ -12,10 +12,10 @@
 
 @implementation NSDictionary (MTLMappingAdditions)
 
-+ (NSDictionary *)mtl_identityPropertyMapWithModel:(Class)class {
-	NSCParameterAssert([class isSubclassOfClass:MTLModel.class]);
++ (NSDictionary *)mtl_identityPropertyMapWithModel:(Class)modelClass {
+	NSCParameterAssert([modelClass isSubclassOfClass:MTLModel.class]);
 
-	NSArray *propertyKeys = [class propertyKeys].allObjects;
+	NSArray *propertyKeys = [modelClass propertyKeys].allObjects;
 
 	return [NSDictionary dictionaryWithObjects:propertyKeys forKeys:propertyKeys];
 }

--- a/Mantle/NSValueTransformer+MTLPredefinedTransformerAdditions.h
+++ b/Mantle/NSValueTransformer+MTLPredefinedTransformerAdditions.h
@@ -70,7 +70,7 @@ extern NSString * const MTLBooleanValueTransformerName;
 ///
 /// Returns a transformer which will return an error if the transformed in value
 /// is not a member of class. Otherwise, the value is simply passed through.
-+ (NSValueTransformer<MTLTransformerErrorHandling> *)mtl_validatingTransformerForClass:(Class)class;
++ (NSValueTransformer<MTLTransformerErrorHandling> *)mtl_validatingTransformerForClass:(Class)modelClass;
 
 + (NSValueTransformer<MTLTransformerErrorHandling> *)mtl_JSONDictionaryTransformerWithModelClass:(Class)modelClass __attribute__((deprecated("Replaced by +[MTLJSONAdapter dictionaryTransformerWithModelClass:]")));
 

--- a/Mantle/NSValueTransformer+MTLPredefinedTransformerAdditions.m
+++ b/Mantle/NSValueTransformer+MTLPredefinedTransformerAdditions.m
@@ -228,15 +228,15 @@ NSString * const MTLBooleanValueTransformerName = @"MTLBooleanValueTransformerNa
 	}
 }
 
-+ (NSValueTransformer<MTLTransformerErrorHandling> *)mtl_validatingTransformerForClass:(Class)class {
-	NSParameterAssert(class != nil);
++ (NSValueTransformer<MTLTransformerErrorHandling> *)mtl_validatingTransformerForClass:(Class)modelClass {
+	NSParameterAssert(modelClass != nil);
 
 	return [MTLValueTransformer transformerUsingForwardBlock:^ id (id value, BOOL *success, NSError **error) {
-		if (value != nil && ![value isKindOfClass:class]) {
+		if (value != nil && ![value isKindOfClass:modelClass]) {
 			if (error != NULL) {
 				NSDictionary *userInfo = @{
 										   NSLocalizedDescriptionKey: NSLocalizedString(@"Value did not match expected type", @""),
-										   NSLocalizedFailureReasonErrorKey: [NSString stringWithFormat:NSLocalizedString(@"Expected %1$@ to be of class %2$@", @""), value, class],
+										   NSLocalizedFailureReasonErrorKey: [NSString stringWithFormat:NSLocalizedString(@"Expected %1$@ to be of class %2$@", @""), value, modelClass],
 										   MTLTransformerErrorHandlingInputValueErrorKey : value
 										   };
 


### PR DESCRIPTION
Related to https://github.com/Mantle/Mantle/commit/ddf43709de66e9cdf2dc2f48c015cbd17c302893

```class``` is a reserved word when including Objective-c++ in the project. 