### PR TITLE
Update JSONDictionaryFromModel: method in MTLJSONAdapter

### DIFF
--- a/Mantle/MTLJSONAdapter.m
+++ b/Mantle/MTLJSONAdapter.m
@@ -184,10 +184,13 @@ static NSString * const MTLJSONAdapterThrownExceptionErrorKey = @"MTLJSONAdapter
 		return [otherAdapter JSONDictionaryFromModel:model error:error];
 	}
 
-	NSSet *propertyKeysToSerialize = [self serializablePropertyKeys:[NSSet setWithArray:self.JSONKeyPathsByPropertyKey.allKeys] forModel:model];
-
-	NSDictionary *dictionaryValue = [model.dictionaryValue dictionaryWithValuesForKeys:propertyKeysToSerialize.allObjects];
-	NSMutableDictionary *JSONDictionary = [[NSMutableDictionary alloc] initWithCapacity:dictionaryValue.count];
+    NSMutableSet *propertyKeysToSerialize = [[self serializablePropertyKeys:[NSSet setWithArray:self.JSONKeyPathsByPropertyKey.allKeys] forModel:model] mutableCopy];
+    
+    NSMutableDictionary *dictionaryValue = [[model dictionaryValue] mutableCopy];
+    [propertyKeysToSerialize intersectSet:[NSSet setWithArray:[dictionaryValue allKeys]]];
+    
+    [dictionaryValue dictionaryWithValuesForKeys:propertyKeysToSerialize.allObjects];
+    NSMutableDictionary *JSONDictionary = [[NSMutableDictionary alloc] initWithCapacity:dictionaryValue.count];
 
 	__block BOOL success = YES;
 	__block NSError *tmpError = nil;

--- a/Mantle/MTLJSONAdapter.m
+++ b/Mantle/MTLJSONAdapter.m
@@ -186,10 +186,10 @@ static NSString * const MTLJSONAdapterThrownExceptionErrorKey = @"MTLJSONAdapter
 
     NSMutableSet *propertyKeysToSerialize = [[self serializablePropertyKeys:[NSSet setWithArray:self.JSONKeyPathsByPropertyKey.allKeys] forModel:model] mutableCopy];
     
-    NSMutableDictionary *dictionaryValue = [[model dictionaryValue] mutableCopy];
+    NSDictionary *dictionaryValue = [model dictionaryValue];
     [propertyKeysToSerialize intersectSet:[NSSet setWithArray:[dictionaryValue allKeys]]];
     
-    [dictionaryValue dictionaryWithValuesForKeys:propertyKeysToSerialize.allObjects];
+    dictionaryValue = [dictionaryValue dictionaryWithValuesForKeys:propertyKeysToSerialize.allObjects];
     NSMutableDictionary *JSONDictionary = [[NSMutableDictionary alloc] initWithCapacity:dictionaryValue.count];
 
 	__block BOOL success = YES;


### PR DESCRIPTION
This update addresses a deficiency in Mantle 2.0 where work done in a model subclass `dictionaryValue:` method is ignored during serialization.

A side effect of this update is that any keys that are _added_ via `serializablePropertyKeys:` will be ignored. However any keys that are removed via this method will be removed during serialization. The assumption is that adding a key in `serializablePropertyKeys:` isn't nearly as useful because the model would have no way to map a value to that new key (unless work in `dictionaryValue:` is done as well).

The biggest thing this update solves is backwards compatibility as it respects any work previously being done in `dictionaryValue:`. Also this removes the requirement to subclass the adapter anytime serialization manipulation needs to be done (like dropping null values). This is particularly useful because the models are already subclasses and come with a purpose built method for manipulating their dictionary representation. And thus can be done on a per model basis or handled in a base model class that overrides `dictionaryValue` and handles default manipulation logic.