### PR TITLE
Replaced use of NSInvocation with direct IMP calls for performance.

### DIFF
--- a/Mantle/MTLJSONAdapter.m
+++ b/Mantle/MTLJSONAdapter.m
@@ -371,7 +371,7 @@ static NSString * const MTLJSONAdapterThrownExceptionErrorKey = @"MTLJSONAdapter
 		SEL selector = MTLSelectorWithKeyPattern(key, "JSONTransformer");
 		if ([modelClass respondsToSelector:selector]) {
 			IMP imp = [modelClass methodForSelector:selector];
-			NSValueTransformer*(*function)(id, SEL) = (void *)imp;
+			NSValueTransformer * (*function)(id, SEL) = (NSValueTransformer * (*)(id, SEL))imp;
 			__unsafe_unretained NSValueTransformer *transformer = function(modelClass, selector);
 
 			if (transformer != nil) result[key] = transformer;
@@ -444,9 +444,9 @@ static NSString * const MTLJSONAdapterThrownExceptionErrorKey = @"MTLJSONAdapter
 
 	SEL selector = MTLSelectorWithKeyPattern(NSStringFromClass(modelClass), "JSONTransformer");
 	if (![self respondsToSelector:selector]) return nil;
-
+	
 	IMP imp = [self methodForSelector:selector];
-	NSValueTransformer*(*function)(id, SEL) = (void *)imp;
+	NSValueTransformer * (*function)(id, SEL) = (NSValueTransformer * (*)(id, SEL))imp;
 	__unsafe_unretained NSValueTransformer *result = function(self, selector);
 	
 	return result;

--- a/Mantle/MTLJSONAdapter.m
+++ b/Mantle/MTLJSONAdapter.m
@@ -370,13 +370,9 @@ static NSString * const MTLJSONAdapterThrownExceptionErrorKey = @"MTLJSONAdapter
 	for (NSString *key in [modelClass propertyKeys]) {
 		SEL selector = MTLSelectorWithKeyPattern(key, "JSONTransformer");
 		if ([modelClass respondsToSelector:selector]) {
-			NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:[modelClass methodSignatureForSelector:selector]];
-			invocation.target = modelClass;
-			invocation.selector = selector;
-			[invocation invoke];
-
-			__unsafe_unretained id transformer = nil;
-			[invocation getReturnValue:&transformer];
+			IMP imp = [modelClass methodForSelector:selector];
+			NSValueTransformer*(*function)(id, SEL) = (void *)imp;
+			__unsafe_unretained NSValueTransformer *transformer = function(modelClass, selector);
 
 			if (transformer != nil) result[key] = transformer;
 
@@ -449,13 +445,10 @@ static NSString * const MTLJSONAdapterThrownExceptionErrorKey = @"MTLJSONAdapter
 	SEL selector = MTLSelectorWithKeyPattern(NSStringFromClass(modelClass), "JSONTransformer");
 	if (![self respondsToSelector:selector]) return nil;
 
-	NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:[self methodSignatureForSelector:selector]];
-	invocation.target = self;
-	invocation.selector = selector;
-	[invocation invoke];
-
-	__unsafe_unretained id result = nil;
-	[invocation getReturnValue:&result];
+	IMP imp = [self methodForSelector:selector];
+	NSValueTransformer*(*function)(id, SEL) = (void *)imp;
+	__unsafe_unretained NSValueTransformer *result = function(self, selector);
+	
 	return result;
 }
 

--- a/Mantle/MTLModel+NSCoding.m
+++ b/Mantle/MTLModel+NSCoding.m
@@ -129,7 +129,7 @@ static void verifyAllowedClassesByPropertyKey(Class modelClass) {
 	SEL selector = MTLSelectorWithCapitalizedKeyPattern("decode", key, "WithCoder:modelVersion:");
 	if ([self respondsToSelector:selector]) {
 		IMP imp = [self methodForSelector:selector];
-		id(*function)(id, SEL, id, NSUInteger) = (void *)imp;
+		id (*function)(id, SEL, NSCoder *, NSUInteger) = (id (*)(id, SEL, NSCoder *, NSUInteger))imp;
 		__unsafe_unretained id result = function(self, selector, coder, modelVersion);
 		
 		return result;

--- a/Mantle/MTLModel+NSCoding.m
+++ b/Mantle/MTLModel+NSCoding.m
@@ -128,15 +128,10 @@ static void verifyAllowedClassesByPropertyKey(Class modelClass) {
 
 	SEL selector = MTLSelectorWithCapitalizedKeyPattern("decode", key, "WithCoder:modelVersion:");
 	if ([self respondsToSelector:selector]) {
-		NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:[self methodSignatureForSelector:selector]];
-		invocation.target = self;
-		invocation.selector = selector;
-		[invocation setArgument:&coder atIndex:2];
-		[invocation setArgument:&modelVersion atIndex:3];
-		[invocation invoke];
-
-		__unsafe_unretained id result = nil;
-		[invocation getReturnValue:&result];
+		IMP imp = [self methodForSelector:selector];
+		id(*function)(id, SEL, id, NSUInteger) = (void *)imp;
+		__unsafe_unretained id result = function(self, selector, coder, modelVersion);
+		
 		return result;
 	}
 

--- a/Mantle/MTLModel.m
+++ b/Mantle/MTLModel.m
@@ -252,12 +252,9 @@ static BOOL MTLValidateAndSetValue(id obj, NSString *key, id value, BOOL forceUp
 		return;
 	}
 
-	NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:[self methodSignatureForSelector:selector]];
-	invocation.target = self;
-	invocation.selector = selector;
-
-	[invocation setArgument:&model atIndex:2];
-	[invocation invoke];
+	IMP imp = [self methodForSelector:selector];
+	void(*function)(id, SEL, id) = (void *)imp;
+	function(self, selector, model);
 }
 
 - (void)mergeValuesForKeysFromModel:(id<MTLModel>)model {

--- a/Mantle/MTLModel.m
+++ b/Mantle/MTLModel.m
@@ -253,7 +253,7 @@ static BOOL MTLValidateAndSetValue(id obj, NSString *key, id value, BOOL forceUp
 	}
 
 	IMP imp = [self methodForSelector:selector];
-	void(*function)(id, SEL, id) = (void *)imp;
+	void (*function)(id, SEL, id<MTLModel>) = (void (*)(id, SEL, id<MTLModel>))imp;
 	function(self, selector, model);
 }
 


### PR DESCRIPTION
The `NSInvocation` isn't used in any interesting way in Mantle, but it's overhead is incurred. If you know what the method looks like, direct calls are much more efficient. Here is a benchmark of 1 million calls of each:

```
NSInvocation: 1419.99ms
Direct Call: 27.43ms
```

I have a large model and the milliseconds that this buys would be much appreciated. There is pretty much no downside here.

```
    int iterations = 1000000;
    
    Class obj = [NSObject class];
    SEL selector = @selector(class);
    
    Time(@"NSInvocation", {
        for (int i = 0; i < iterations; i++) {
            NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:[obj methodSignatureForSelector:selector]];
            invocation.target = obj;
            invocation.selector = selector;
            [invocation invoke];
            
            __unsafe_unretained id result = nil;
            [invocation getReturnValue:&result];
            result = nil;
        }
    });
        
    Time(@"Direct Call", {
        for (int i = 0; i < iterations; i++) {
            IMP imp = [obj methodForSelector:selector];
            NSValueTransformer*(*function)(id, SEL) = (void *)imp;
            __unsafe_unretained id result = function(obj, selector);
            result = nil;
        }
    });
```