### PR TITLE
Fix __unsafe_unretained crashes in IMP returns

### DIFF
--- a/Mantle.xcodeproj/xcshareddata/xcschemes/Mantle Mac.xcscheme
+++ b/Mantle.xcodeproj/xcshareddata/xcschemes/Mantle Mac.xcscheme
@@ -40,7 +40,7 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
-      buildConfiguration = "Debug">
+      buildConfiguration = "Release">
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/Mantle/MTLJSONAdapter.m
+++ b/Mantle/MTLJSONAdapter.m
@@ -371,8 +371,8 @@ static NSString * const MTLJSONAdapterThrownExceptionErrorKey = @"MTLJSONAdapter
 		SEL selector = MTLSelectorWithKeyPattern(key, "JSONTransformer");
 		if ([modelClass respondsToSelector:selector]) {
 			IMP imp = [modelClass methodForSelector:selector];
-			NSValueTransformer * (*function)(id, SEL) = (NSValueTransformer * (*)(id, SEL))imp;
-			__unsafe_unretained NSValueTransformer *transformer = function(modelClass, selector);
+			NSValueTransformer * (*function)(id, SEL) = (__typeof__(function))imp;
+			NSValueTransformer *transformer = function(modelClass, selector);
 
 			if (transformer != nil) result[key] = transformer;
 
@@ -446,8 +446,8 @@ static NSString * const MTLJSONAdapterThrownExceptionErrorKey = @"MTLJSONAdapter
 	if (![self respondsToSelector:selector]) return nil;
 	
 	IMP imp = [self methodForSelector:selector];
-	NSValueTransformer * (*function)(id, SEL) = (NSValueTransformer * (*)(id, SEL))imp;
-	__unsafe_unretained NSValueTransformer *result = function(self, selector);
+	NSValueTransformer * (*function)(id, SEL) = (__typeof__(function))imp;
+	NSValueTransformer *result = function(self, selector);
 	
 	return result;
 }

--- a/Mantle/MTLModel+NSCoding.m
+++ b/Mantle/MTLModel+NSCoding.m
@@ -129,8 +129,8 @@ static void verifyAllowedClassesByPropertyKey(Class modelClass) {
 	SEL selector = MTLSelectorWithCapitalizedKeyPattern("decode", key, "WithCoder:modelVersion:");
 	if ([self respondsToSelector:selector]) {
 		IMP imp = [self methodForSelector:selector];
-		id (*function)(id, SEL, NSCoder *, NSUInteger) = (id (*)(id, SEL, NSCoder *, NSUInteger))imp;
-		__unsafe_unretained id result = function(self, selector, coder, modelVersion);
+		id (*function)(id, SEL, NSCoder *, NSUInteger) = (__typeof__(function))imp;
+		id result = function(self, selector, coder, modelVersion);
 		
 		return result;
 	}

--- a/Mantle/MTLModel.m
+++ b/Mantle/MTLModel.m
@@ -253,7 +253,7 @@ static BOOL MTLValidateAndSetValue(id obj, NSString *key, id value, BOOL forceUp
 	}
 
 	IMP imp = [self methodForSelector:selector];
-	void (*function)(id, SEL, id<MTLModel>) = (void (*)(id, SEL, id<MTLModel>))imp;
+	void (*function)(id, SEL, id<MTLModel>) = (__typeof__(function))imp;
 	function(self, selector, model);
 }
 

--- a/MantleTests/MTLJSONAdapterSpec.m
+++ b/MantleTests/MTLJSONAdapterSpec.m
@@ -14,6 +14,21 @@
 #import "MTLTestModel.h"
 #import "MTLTransformerErrorExamples.h"
 
+@interface MTLJSONAdapter (SpecExtensions)
+
+// Used for testing transformer lifetimes.
++ (NSValueTransformer *)NSDateJSONTransformer;
+
+@end
+
+@implementation MTLJSONAdapter (SpecExtensions)
+
++ (NSValueTransformer *)NSDateJSONTransformer {
+	return [[NSValueTransformer alloc] init];
+}
+
+@end
+
 QuickSpecBegin(MTLJSONAdapterSpec)
 
 it(@"should initialize with a model class", ^{
@@ -547,6 +562,19 @@ it(@"should return an array of dictionaries from models", ^{
 	expect(@(JSONArray.count)).to(equal(@2));
 	expect(JSONArray[0][@"username"]).to(equal(@"foo"));
 	expect(JSONArray[1][@"username"]).to(equal(@"bar"));
+});
+
+it(@"should not leak transformers", ^{
+	__weak id weakTransformer;
+
+	@autoreleasepool {
+		id transformer = [MTLJSONAdapter transformerForModelPropertiesOfClass:NSDate.class];
+		weakTransformer = transformer;
+
+		expect(transformer).notTo(beNil());
+	}
+
+	expect(weakTransformer).toEventually(beNil());
 });
 
 QuickSpecEnd


### PR DESCRIPTION
#520 introduced potential crashes around the `IMP` calls, because the `NSValueTransformer`s returned weren't being retained.

The crashes only present themselves in Release builds, so I missed it originally. Once our test suite is switched to Release, they become evident.

Sorry for missing it originally!

/cc @adamkaplan