### PR TITLE
Make BooleanTransformer also responses to NSString, not only NSNumber.

### DIFF
--- a/Mantle/NSValueTransformer+MTLPredefinedTransformerAdditions.m
+++ b/Mantle/NSValueTransformer+MTLPredefinedTransformerAdditions.m
@@ -81,11 +81,11 @@ NSString * const MTLBooleanValueTransformerName = @"MTLBooleanValueTransformerNa
 			transformerUsingReversibleBlock:^ id (NSNumber *boolean, BOOL *success, NSError **error) {
 				if (boolean == nil) return nil;
 
-				if (![boolean isKindOfClass:NSNumber.class]) {
+				if (![boolean isKindOfClass:NSNumber.class] && ![boolean isKindOfClass:NSString.class]) {
 					if (error != NULL) {
 						NSDictionary *userInfo = @{
-							NSLocalizedDescriptionKey: NSLocalizedString(@"Could not convert number to boolean-backed number or vice-versa", @""),
-							NSLocalizedFailureReasonErrorKey: [NSString stringWithFormat:NSLocalizedString(@"Expected an NSNumber, got: %@.", @""), boolean],
+							NSLocalizedDescriptionKey: NSLocalizedString(@"Could not convert number or string to boolean-backed number or vice-versa", @""),
+							NSLocalizedFailureReasonErrorKey: [NSString stringWithFormat:NSLocalizedString(@"Expected an NSNumber or NSString, got: %@.", @""), boolean],
 							MTLTransformerErrorHandlingInputValueErrorKey : boolean
 						};
 


### PR DESCRIPTION
Sometimes we use a json code like this: {key1:false, key2:true}. It turns out the value is a NSString, and the BooleanTransformer refuse to convert NSString to boolean (only convert NSNumber to booleanValue). So I think we need this to be supported.