### PR TITLE
Transform the json with dictionaryTransformer by default.

### DIFF
--- a/Mantle/MTLJSONAdapter.m
+++ b/Mantle/MTLJSONAdapter.m
@@ -406,7 +406,7 @@ static NSString * const MTLJSONAdapterThrownExceptionErrorKey = @"MTLJSONAdapter
 			}
 			
 			// For User defined MTLModel, we should try to parse it with dictionaryTransformer, since we are inside of json adapter now.
-			if (nil == transformer && [propertyClass isSubclassOfClass:MTLModel.class]) {
+			if (nil == transformer && [propertyClass conformsToProtocol:@protocol(MTLJSONSerializing)]) {
 				transformer = [MTLJSONAdapter dictionaryTransformerWithModelClass:propertyClass];
 			}
 			

--- a/Mantle/MTLJSONAdapter.m
+++ b/Mantle/MTLJSONAdapter.m
@@ -404,7 +404,12 @@ static NSString * const MTLJSONAdapterThrownExceptionErrorKey = @"MTLJSONAdapter
 			if (propertyClass != nil) {
 				transformer = [self transformerForModelPropertiesOfClass:propertyClass];
 			}
-
+			
+			// For User defined MTLModel, we should try to parse it with dictionaryTransformer, since we are inside of json adapter now.
+			if (nil == transformer && [propertyClass isSubclassOfClass:MTLModel.class]) {
+				transformer = [MTLJSONAdapter dictionaryTransformerWithModelClass:propertyClass];
+			}
+			
 			if (transformer == nil) transformer = [NSValueTransformer mtl_validatingTransformerForClass:NSObject.class];
 		} else {
 			transformer = [self transformerForModelPropertiesOfObjCType:attributes->type] ?: [NSValueTransformer mtl_validatingTransformerForClass:NSValue.class];

--- a/Mantle/MTLJSONAdapter.m
+++ b/Mantle/MTLJSONAdapter.m
@@ -407,7 +407,7 @@ static NSString * const MTLJSONAdapterThrownExceptionErrorKey = @"MTLJSONAdapter
 			
 			// For User defined MTLModel, we should try to parse it with dictionaryTransformer, since we are inside of json adapter now.
 			if (nil == transformer && [propertyClass conformsToProtocol:@protocol(MTLJSONSerializing)]) {
-				transformer = [MTLJSONAdapter dictionaryTransformerWithModelClass:propertyClass];
+				transformer = [self dictionaryTransformerWithModelClass:propertyClass];
 			}
 			
 			if (transformer == nil) transformer = [NSValueTransformer mtl_validatingTransformerForClass:NSObject.class];

--- a/MantleTests/MTLJSONAdapterSpec.m
+++ b/MantleTests/MTLJSONAdapterSpec.m
@@ -577,4 +577,56 @@ it(@"should not leak transformers", ^{
 	expect(weakTransformer).toEventually(beNil());
 });
 
+it(@"should initialize a MTLJSONSerializingProperty with MTLJSONAdapter by default", ^{
+	NSDictionary *serializingValues = @{
+							 @"username": @"testName",
+							 @"count": @"5",
+							 };
+	
+	
+	NSDictionary *JSONDictionary = @{
+									 @"property": @"property0",
+									 @"mtlJSONSerializingProperty": serializingValues,
+									 @"nonMTLJSONSerializingProperty": @{}
+									 };
+	
+	MTLJSONAdapter *adapter = [[MTLJSONAdapter alloc] initWithModelClass:MTLPropertyModel.class];
+	expect(adapter).notTo(beNil());
+	
+	NSError *error = nil;
+	MTLPropertyModel *model = [adapter modelFromJSONDictionary:JSONDictionary error:&error];
+	expect(error).to(beNil());
+	
+	expect(model).notTo(beNil());
+	expect(model.property).to(equal(@"property0"));
+	expect(model.mtlJSONSerializingProperty).notTo(beNil());
+	expect(model.mtlJSONSerializingProperty.name).to(equal(@"testName"));
+	
+});
+
+it(@"should only initialize a MTLJSONSerializingProperty with MTLJSONAdaptor by default, not MTLModel", ^{
+	NSDictionary *serializingValues = @{
+										@"username": @"testName",
+										@"count": @"5",
+										};
+	
+	
+	NSDictionary *JSONDictionary = @{
+									 @"property": @"property0",
+									 @"mtlJSONSerializingProperty": serializingValues,
+									 @"nonMTLJSONSerializingProperty": @{}
+									 };
+	
+	MTLJSONAdapter *adapter = [[MTLJSONAdapter alloc] initWithModelClass:MTLPropertyModel.class];
+	expect(adapter).notTo(beNil());
+	
+	NSError *error = nil;
+	MTLPropertyModel *model = [adapter modelFromJSONDictionary:JSONDictionary error:&error];
+	expect(error).to(beNil());
+	expect(model).notTo(beNil());
+	
+	NSString *emptyModel = NSStringFromClass(MTLTestModel.class);
+	NSString *propertyType = NSStringFromClass(model.nonMTLJSONSerializingProperty.class);
+	expect(propertyType).notTo(equal(emptyModel));
+});
 QuickSpecEnd

--- a/MantleTests/MTLTestModel.h
+++ b/MantleTests/MTLTestModel.h
@@ -148,3 +148,10 @@ extern const NSInteger MTLTestModelNameMissing;
 @property (readwrite, nonatomic, assign) NSUInteger freshness;
 
 @end
+
+// This is for testing parsing MTLJSONSerializing property by default.
+@interface MTLPropertyModel : MTLModel<MTLJSONSerializing>
+@property (readonly, nonatomic, assign) NSString *property;
+@property (readonly, nonatomic, strong) MTLTestModel *mtlJSONSerializingProperty;
+@property (readonly, nonatomic, strong) MTLEmptyTestModel *nonMTLJSONSerializingProperty;
+@end

--- a/MantleTests/MTLTestModel.m
+++ b/MantleTests/MTLTestModel.m
@@ -454,3 +454,15 @@ static NSUInteger modelVersion = 1;
 }
 
 @end
+
+@implementation MTLPropertyModel
+
++ (NSDictionary *)JSONKeyPathsByPropertyKey {
+	return @{
+				@"property": @"property",
+				@"mtlJSONSerializingProperty": @"mtlJSONSerializingProperty",
+				@"nonMTLJSONSerializingProperty": @"nonMTLJSONSerializingProperty"
+			};;
+}
+
+@end


### PR DESCRIPTION
In case user's model class specify no transformer for User defined MTLModel subclass, we should try to parse it with dictionaryTransformer by default, in side of MTLJSONAdapter adapter, because we are parsing json.