### PR TITLE
Unimplemented, unmapped, optional protocol properties return MTLStoragePropertyNone from MTLModel +storageBehaviorForPropertyWithKeys:

### DIFF
--- a/Mantle/MTLModel.m
+++ b/Mantle/MTLModel.m
@@ -230,8 +230,12 @@ static BOOL MTLValidateAndSetValue(id obj, NSString *key, id value, BOOL forceUp
 	@onExit {
 		free(attributes);
 	};
-
-	if (attributes->readonly && attributes->ivar == NULL) {
+	
+	Method getterMethod = class_getInstanceMethod(self.class, attributes->getter);
+	Method setterMethod = class_getInstanceMethod(self.class, attributes->setter);
+	if (!attributes->dynamic && attributes->ivar == NULL && getterMethod == NULL && setterMethod == NULL) {
+		return MTLPropertyStorageNone;
+	} else if (attributes->readonly && attributes->ivar == NULL) {
 		return MTLPropertyStorageNone;
 	} else {
 		return MTLPropertyStoragePermanent;

--- a/MantleTests/MTLModelSpec.m
+++ b/MantleTests/MTLModelSpec.m
@@ -190,4 +190,9 @@ describe(@"merging with model subclasses", ^{
 	});
 });
 
+it(@"should ignore optional protocol properties not implemented", ^{
+	expect(@([MTLOptionalPropertyModel storageBehaviorForPropertyWithKey:@"optionalProperty"])).to(equal(@(MTLPropertyStorageNone)));
+});
+
+
 QuickSpecEnd

--- a/MantleTests/MTLTestModel.h
+++ b/MantleTests/MTLTestModel.h
@@ -154,3 +154,15 @@ extern const NSInteger MTLTestModelNameMissing;
 @property (readwrite, nonatomic, assign) NSUInteger freshness;
 
 @end
+
+
+@protocol MTLOptionalPropertyProtocol
+
+@optional
+@property (readwrite, nonatomic, copy) NSString *optionalProperty;
+
+@end
+
+@interface MTLOptionalPropertyModel : MTLModel <MTLOptionalPropertyProtocol>
+
+@end

--- a/MantleTests/MTLTestModel.m
+++ b/MantleTests/MTLTestModel.m
@@ -462,3 +462,7 @@ static NSUInteger modelVersion = 1;
 }
 
 @end
+
+@implementation MTLOptionalPropertyModel
+
+@end


### PR DESCRIPTION
Attempt to handle Issue [#523](https://github.com/Mantle/Mantle/issues/523)
