### PR TITLE
skip re-validation in -[MTLModel copyWithZone:]

### DIFF
--- a/Mantle/MTLModel.m
+++ b/Mantle/MTLModel.m
@@ -283,7 +283,9 @@ static BOOL MTLValidateAndSetValue(id obj, NSString *key, id value, BOOL forceUp
 #pragma mark NSCopying
 
 - (instancetype)copyWithZone:(NSZone *)zone {
-	return [[self.class allocWithZone:zone] initWithDictionary:self.dictionaryValue error:NULL];
+	MTLModel *copy = [[self.class allocWithZone:zone] init];
+	[copy setValuesForKeysWithDictionary:self.dictionaryValue];
+	return copy;
 }
 
 #pragma mark NSObject


### PR DESCRIPTION
I can't think of any situation where `-[MTLModel dictionaryValue]` would return a dictionary representation of a model that isn't valid to re-use for future objects, so, lets skip validation in this case, and have a nice little perf gain.

I implemented this as a separate (private) initialization method + function to avoid adding branches or changing the default behavior of `-[MTLModel initWithDictionary:error:]` / `-[MTLModel modelWithDictionary:error:]`