### PR TITLE
Pretty-printing of Mantle objects

### DIFF
--- a/Mantle.xcodeproj/project.pbxproj
+++ b/Mantle.xcodeproj/project.pbxproj
@@ -113,6 +113,10 @@
 		D0F117491614C5600092520B /* NSValueTransformer+MTLPredefinedTransformerAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = D0F117471614C5600092520B /* NSValueTransformer+MTLPredefinedTransformerAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D0F1174A1614C5600092520B /* NSValueTransformer+MTLPredefinedTransformerAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = D0F117481614C5600092520B /* NSValueTransformer+MTLPredefinedTransformerAdditions.m */; };
 		D0F1174D1614C8000092520B /* MTLPredefinedTransformerAdditionsSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = D0F1174C1614C8000092520B /* MTLPredefinedTransformerAdditionsSpec.m */; };
+		E68AD4DB1B4C985B008EA220 /* NSObject+MTLDescription.h in Headers */ = {isa = PBXBuildFile; fileRef = E68AD4D91B4C985B008EA220 /* NSObject+MTLDescription.h */; };
+		E68AD4DC1B4C985B008EA220 /* NSObject+MTLDescription.h in Headers */ = {isa = PBXBuildFile; fileRef = E68AD4D91B4C985B008EA220 /* NSObject+MTLDescription.h */; };
+		E68AD4DD1B4C985B008EA220 /* NSObject+MTLDescription.m in Sources */ = {isa = PBXBuildFile; fileRef = E68AD4DA1B4C985B008EA220 /* NSObject+MTLDescription.m */; };
+		E68AD4DE1B4C985B008EA220 /* NSObject+MTLDescription.m in Sources */ = {isa = PBXBuildFile; fileRef = E68AD4DA1B4C985B008EA220 /* NSObject+MTLDescription.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -238,6 +242,8 @@
 		D0F117471614C5600092520B /* NSValueTransformer+MTLPredefinedTransformerAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSValueTransformer+MTLPredefinedTransformerAdditions.h"; sourceTree = "<group>"; };
 		D0F117481614C5600092520B /* NSValueTransformer+MTLPredefinedTransformerAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSValueTransformer+MTLPredefinedTransformerAdditions.m"; sourceTree = "<group>"; };
 		D0F1174C1614C8000092520B /* MTLPredefinedTransformerAdditionsSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MTLPredefinedTransformerAdditionsSpec.m; sourceTree = "<group>"; };
+		E68AD4D91B4C985B008EA220 /* NSObject+MTLDescription.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSObject+MTLDescription.h"; sourceTree = "<group>"; };
+		E68AD4DA1B4C985B008EA220 /* NSObject+MTLDescription.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSObject+MTLDescription.m"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -433,6 +439,8 @@
 				54EDCD0918D9B34F005796FC /* NSDictionary+MTLJSONKeyPath.m */,
 				1ED5B5CE163A4E3C0072668E /* NSObject+MTLComparisonAdditions.h */,
 				1ED5B5CF163A4E3C0072668E /* NSObject+MTLComparisonAdditions.m */,
+				E68AD4D91B4C985B008EA220 /* NSObject+MTLDescription.h */,
+				E68AD4DA1B4C985B008EA220 /* NSObject+MTLDescription.m */,
 				D0BFC36D17476B4700F5DC5D /* NSValueTransformer+MTLInversionAdditions.h */,
 				D0BFC36E17476B4700F5DC5D /* NSValueTransformer+MTLInversionAdditions.m */,
 				D0F117471614C5600092520B /* NSValueTransformer+MTLPredefinedTransformerAdditions.h */,
@@ -538,6 +546,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E68AD4DB1B4C985B008EA220 /* NSObject+MTLDescription.h in Headers */,
 				D0760E0515FFBD440060F550 /* Mantle.h in Headers */,
 				D0760E7815FFBF330060F550 /* MTLModel.h in Headers */,
 				D08B5AAE16002694001FE685 /* MTLValueTransformer.h in Headers */,
@@ -557,6 +566,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E68AD4DC1B4C985B008EA220 /* NSObject+MTLDescription.h in Headers */,
 				D0E9C38319F6DC5B000D427D /* NSArray+MTLManipulationAdditions.h in Headers */,
 				D0E9C37919F6DC5B000D427D /* MTLModel+NSCoding.h in Headers */,
 				D0E9C38919F6DC5B000D427D /* NSObject+MTLComparisonAdditions.h in Headers */,
@@ -732,6 +742,7 @@
 				D05317731A168D3D00A5FBE2 /* MTLTransformerErrorHandling.m in Sources */,
 				1ED5B5D1163A4E3C0072668E /* NSObject+MTLComparisonAdditions.m in Sources */,
 				D05317771A168D6D00A5FBE2 /* NSDictionary+MTLJSONKeyPath.m in Sources */,
+				E68AD4DD1B4C985B008EA220 /* NSObject+MTLDescription.m in Sources */,
 				D01BD09F16CB432D00EC95C7 /* MTLJSONAdapter.m in Sources */,
 				54803A34178829A800011B39 /* NSError+MTLModelException.m in Sources */,
 				D01BD0B116CB52E800EC95C7 /* MTLModel+NSCoding.m in Sources */,
@@ -778,6 +789,7 @@
 				D0E9C37A19F6DC5B000D427D /* MTLModel+NSCoding.m in Sources */,
 				D0E9C38A19F6DC5B000D427D /* NSObject+MTLComparisonAdditions.m in Sources */,
 				D0E9C37819F6DC5B000D427D /* MTLModel.m in Sources */,
+				E68AD4DE1B4C985B008EA220 /* NSObject+MTLDescription.m in Sources */,
 				D0E9C37E19F6DC5B000D427D /* MTLJSONAdapter.m in Sources */,
 				D0E9C38419F6DC5B000D427D /* NSArray+MTLManipulationAdditions.m in Sources */,
 				D05317751A168D3D00A5FBE2 /* MTLTransformerErrorHandling.m in Sources */,

--- a/Mantle/MTLModel.m
+++ b/Mantle/MTLModel.m
@@ -11,6 +11,7 @@
 #import "EXTRuntimeExtensions.h"
 #import "EXTScope.h"
 #import "MTLReflection.h"
+#import "NSObject+MTLDescription.h"
 #import <objc/runtime.h>
 
 // Used to cache the reflection performed in +propertyKeys.
@@ -291,7 +292,7 @@ static BOOL MTLValidateAndSetValue(id obj, NSString *key, id value, BOOL forceUp
 - (NSString *)description {
 	NSDictionary *permanentProperties = [self dictionaryWithValuesForKeys:self.class.permanentPropertyKeys.allObjects];
 
-	return [NSString stringWithFormat:@"<%@: %p> %@", self.class, self, permanentProperties];
+	return [NSString stringWithFormat:@"<%@: %p> %@", self.class, self, [permanentProperties mtl_description]];
 }
 
 - (NSUInteger)hash {

--- a/Mantle/NSObject+MTLDescription.h
+++ b/Mantle/NSObject+MTLDescription.h
@@ -1,0 +1,13 @@
+//
+//  NSObject+MTLDescription.h
+//  Mantle
+//
+//  Created by William Green on 2015-07-07.
+//  Copyright (c) 2015 GitHub. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface NSObject (MTLDescription)
+- (NSString *)mtl_description;
+@end

--- a/Mantle/NSObject+MTLDescription.m
+++ b/Mantle/NSObject+MTLDescription.m
@@ -1,0 +1,56 @@
+//
+//  NSObject+MTLDescription.m
+//  Mantle
+//
+//  Created by William Green on 2015-07-07.
+//  Copyright (c) 2015 GitHub. All rights reserved.
+//
+
+#import "NSObject+MTLDescription.h"
+
+@implementation NSObject (MTLDescription)
+
+- (NSString *)mtl_description {
+	if ([self conformsToProtocol:@protocol(NSFastEnumeration)]) {
+		// Print the container
+		NSMutableArray *itemDescriptions = [NSMutableArray array];
+		for (NSObject *obj in (id<NSFastEnumeration>)self) {
+			// TODO: support objects that conform to <NSObject> but are not NSObjects
+			NSString *itemDescription;
+			if ([self respondsToSelector:@selector(objectForKeyedSubscript:)]) {
+				// Use dictionary syntax
+				NSObject *value = [(id)self objectForKeyedSubscript:obj];
+				NSString *valueDescription;
+				if ([value isKindOfClass:[NSString class]]) {
+					// Quote strings if they are values
+					valueDescription = [NSString stringWithFormat:@"\"%@\"", value];
+				} else {
+					valueDescription = [value mtl_description];
+				}
+				itemDescription = [NSString stringWithFormat:@"%@ = %@", [obj mtl_description], valueDescription];
+			} else {
+				itemDescription = [obj mtl_description];
+			}
+			[itemDescriptions addObject:[itemDescription stringByReplacingOccurrencesOfString:@"\n" withString:@"\n\t"]];
+		}
+
+		// Syntax: Dictionary = {}, Array = [], Set = ()
+		NSString *containerStart;
+		NSString *containerEnd;
+		if ([self respondsToSelector:@selector(objectForKeyedSubscript:)]) {
+			containerStart = @"{";
+			containerEnd   = @"}";
+		} else if ([self respondsToSelector:@selector(objectAtIndexedSubscript:)]) {
+			containerStart = @"[";
+			containerEnd   = @"]";
+		} else {
+			containerStart = @"(";
+			containerEnd   = @")";
+		}
+		return [NSString stringWithFormat:@"%@\n\t%@\n%@", containerStart, [itemDescriptions componentsJoinedByString:@",\n\t"], containerEnd];
+	} else {
+		return [self description];
+	}
+}
+
+@end


### PR DESCRIPTION
Improves the printing of complex model hierarchies in `lldb` where combinations of `MTLModel`, `NSDictionary` and `NSArray` would clash. It is a more general issue with Apple's collection types but `-[MTLModel description]` uses it's dictionary representation for printing its properties.

http://stackoverflow.com/questions/21346738/nsdictionary-like-pretty-print-in-the-debugger-or-log


My proposal changes this:
```
(lldb) po feedback
<S9MLFeedback: 0x79b31a50> {
    image = "<S9MLImage: 0x79b3eab0> {\n    size = \"NSSize: {0, 0}\";\n    src = \"assets/image.jpeg\";\n    uuid = \"<null>\";\n}";
    text = "this is some feeback";
}
```

to this:

```
(lldb) po feedback
<S9MLFeedback: 0x78667dd0> {
	image = <S9MLImage: 0x786bc9b0> {
		uuid = <null>,
		src = "assets/image.jpeg",
		size = NSSize: {0, 0}
	},
	text = "this is some feeback"
}
```

It works by implementing a custom description for objects conforming to `NSFastEnumeration` (i.e. `NSDictionary`, `NSArray`, `NSSet`).

- It only replaces the output of collections within `MTLModel`s. All other instances are not affected.
- The descriptions of non-collection types are unchanged.
- The new `mtl_description` is a project header and does not require you to call it to get pretty-printing. 

===

What do you think? If you like the idea then I will clean up the code, add documentation and fix the todos.