### PR TITLE
Fix MTLJSONAdapter subclass not being used in method JSONAdapterForMo…

### DIFF
--- a/Mantle/MTLJSONAdapter.m
+++ b/Mantle/MTLJSONAdapter.m
@@ -425,7 +425,7 @@ static NSString * const MTLJSONAdapterThrownExceptionErrorKey = @"MTLJSONAdapter
 
 		if (result != nil) return result;
 
-		result = [[self class alloc] initWithModelClass:modelClass];
+		result = [[[self class] alloc] initWithModelClass:modelClass];
 
 		if (result != nil) {
 			[self.JSONAdaptersByModelClass setObject:result forKey:modelClass];

--- a/Mantle/MTLJSONAdapter.m
+++ b/Mantle/MTLJSONAdapter.m
@@ -425,7 +425,7 @@ static NSString * const MTLJSONAdapterThrownExceptionErrorKey = @"MTLJSONAdapter
 
 		if (result != nil) return result;
 
-		result = [[MTLJSONAdapter alloc] initWithModelClass:modelClass];
+		result = [[self class alloc] initWithModelClass:modelClass];
 
 		if (result != nil) {
 			[self.JSONAdaptersByModelClass setObject:result forKey:modelClass];

--- a/Mantle/MTLJSONAdapter.m
+++ b/Mantle/MTLJSONAdapter.m
@@ -425,7 +425,7 @@ static NSString * const MTLJSONAdapterThrownExceptionErrorKey = @"MTLJSONAdapter
 
 		if (result != nil) return result;
 
-		result = [[[self class] alloc] initWithModelClass:modelClass];
+		result = [[self.class alloc] initWithModelClass:modelClass];
 
 		if (result != nil) {
 			[self.JSONAdaptersByModelClass setObject:result forKey:modelClass];


### PR DESCRIPTION
Situation:
I have a custom MTLJSONAdapter -> BTJSONAdapter
In my MTLModel subclass, i override classForParsingJSONDictionary and return a custom class. 

Expectation:
My custom BTJSONAdapter should be used.

Result:
My custom BTJSONAdapter is not used. 

Fix:
Use the correct subclass at allocation time.  