### PR TITLE
Check superclass for property persistence

### DIFF
--- a/Mantle/MTLModel.m
+++ b/Mantle/MTLModel.m
@@ -232,7 +232,12 @@ static BOOL MTLValidateAndSetValue(id obj, NSString *key, id value, BOOL forceUp
 	};
 
 	if (attributes->readonly && attributes->ivar == NULL) {
-		return MTLPropertyStorageNone;
+		if ([self isEqual:MTLModel.class]) {
+			return MTLPropertyStorageNone;
+		} else {
+			// Check superclass in case the subclass redeclares a property that falls through
+			return [self.superclass storageBehaviorForPropertyWithKey:propertyKey];
+		}
 	} else {
 		return MTLPropertyStoragePermanent;
 	}

--- a/Mantle/MTLModel.m
+++ b/Mantle/MTLModel.m
@@ -231,9 +231,9 @@ static BOOL MTLValidateAndSetValue(id obj, NSString *key, id value, BOOL forceUp
 		free(attributes);
 	};
 	
-	Method getterMethod = class_getInstanceMethod(self.class, attributes->getter);
-	Method setterMethod = class_getInstanceMethod(self.class, attributes->setter);
-	if (!attributes->dynamic && attributes->ivar == NULL && getterMethod == NULL && setterMethod == NULL) {
+	BOOL hasGetter = [self instancesRespondToSelector:attributes->getter];
+	BOOL hasSetter = [self instancesRespondToSelector:attributes->setter];
+	if (!attributes->dynamic && attributes->ivar == NULL && !hasGetter && !hasSetter) {
 		return MTLPropertyStorageNone;
 	} else if (attributes->readonly && attributes->ivar == NULL) {
 		if ([self isEqual:MTLModel.class]) {

--- a/Mantle/MTLModel.m
+++ b/Mantle/MTLModel.m
@@ -239,7 +239,8 @@ static BOOL MTLValidateAndSetValue(id obj, NSString *key, id value, BOOL forceUp
 		if ([self isEqual:MTLModel.class]) {
 			return MTLPropertyStorageNone;
 		} else {
-			// Check superclass in case the subclass redeclares a property that falls through
+			// Check superclass in case the subclass redeclares a property that
+			// falls through
 			return [self.superclass storageBehaviorForPropertyWithKey:propertyKey];
 		}
 	} else {

--- a/MantleTests/MTLModelSpec.m
+++ b/MantleTests/MTLModelSpec.m
@@ -152,7 +152,7 @@ it(@"should ignore readonly properties without backing ivar", ^{
 });
 
 it(@"should consider properties declared in subclass with storage in superclass permanent", ^{
-	expect(@([MTLStorageBehaviorModelSubclass storageBehaviorForPropertyWithKey:@"strongProperty"])).to(equal(@(MTLPropertyStoragePermanent)));
+	expect(@([MTLStorageBehaviorModelSubclass storageBehaviorForPropertyWithKey:@"shadowedInSubclass"])).to(equal(@(MTLPropertyStoragePermanent)));
 	expect(@([MTLStorageBehaviorModelSubclass storageBehaviorForPropertyWithKey:@"declaredInProtocol"])).to(equal(@(MTLPropertyStoragePermanent)));
 });
 

--- a/MantleTests/MTLModelSpec.m
+++ b/MantleTests/MTLModelSpec.m
@@ -156,8 +156,8 @@ it(@"should ignore readonly properties without backing ivar", ^{
 });
 
 it(@"should consider properties declared in protocol, and backed by ivar in superclass, permanent", ^{
-	expect(@([MTLStorageBehaviorModel storageBehaviorForPropertyWithKey:@"dateFromProtocol"])).to(equal(@(MTLPropertyStoragePermanent)));
-	expect(@([MTLStorageBehaviorModelSubclass storageBehaviorForPropertyWithKey:@"dateFromProtocol"])).to(equal(@(MTLPropertyStoragePermanent)));
+	expect(@([MTLStorageBehaviorModel storageBehaviorForPropertyWithKey:@"declaredInProtocol"])).to(equal(@(MTLPropertyStoragePermanent)));
+	expect(@([MTLStorageBehaviorModelSubclass storageBehaviorForPropertyWithKey:@"declaredInProtocol"])).to(equal(@(MTLPropertyStoragePermanent)));
 });
 
 describe(@"merging with model subclasses", ^{

--- a/MantleTests/MTLModelSpec.m
+++ b/MantleTests/MTLModelSpec.m
@@ -156,6 +156,11 @@ it(@"should consider properties declared in subclass with storage in superclass 
 	expect(@([MTLStorageBehaviorModelSubclass storageBehaviorForPropertyWithKey:@"declaredInProtocol"])).to(equal(@(MTLPropertyStoragePermanent)));
 });
 
+it(@"should ignore optional protocol properties not implemented", ^{
+	expect(@([MTLOptionalPropertyModel storageBehaviorForPropertyWithKey:@"optionalUnimplementedProperty"])).to(equal(@(MTLPropertyStorageNone)));
+	expect(@([MTLOptionalPropertyModel storageBehaviorForPropertyWithKey:@"optionalImplementedProperty"])).to(equal(@(MTLPropertyStoragePermanent)));
+});
+
 describe(@"merging with model subclasses", ^{
 	__block MTLTestModel *superclass;
 	__block MTLSubclassTestModel *subclass;
@@ -193,10 +198,6 @@ describe(@"merging with model subclasses", ^{
 		expect(subclass.generation).to(equal(@1));
 		expect(subclass.role).to(equal(@"subclass"));
 	});
-});
-
-it(@"should ignore optional protocol properties not implemented", ^{
-	expect(@([MTLOptionalPropertyModel storageBehaviorForPropertyWithKey:@"optionalProperty"])).to(equal(@(MTLPropertyStorageNone)));
 });
 
 

--- a/MantleTests/MTLModelSpec.m
+++ b/MantleTests/MTLModelSpec.m
@@ -137,26 +137,22 @@ it(@"should merge two models together", ^{
 
 it(@"should consider primitive properties permanent", ^{
 	expect(@([MTLStorageBehaviorModel storageBehaviorForPropertyWithKey:@"primitive"])).to(equal(@(MTLPropertyStoragePermanent)));
-	expect(@([MTLStorageBehaviorModelSubclass storageBehaviorForPropertyWithKey:@"primitive"])).to(equal(@(MTLPropertyStoragePermanent)));
 });
 
 it(@"should consider object-type assign properties permanent", ^{
 	expect(@([MTLStorageBehaviorModel storageBehaviorForPropertyWithKey:@"assignProperty"])).to(equal(@(MTLPropertyStoragePermanent)));
-	expect(@([MTLStorageBehaviorModelSubclass storageBehaviorForPropertyWithKey:@"assignProperty"])).to(equal(@(MTLPropertyStoragePermanent)));
 });
 
 it(@"should consider object-type strong properties permanent", ^{
 	expect(@([MTLStorageBehaviorModel storageBehaviorForPropertyWithKey:@"strongProperty"])).to(equal(@(MTLPropertyStoragePermanent)));
-	expect(@([MTLStorageBehaviorModelSubclass storageBehaviorForPropertyWithKey:@"strongProperty"])).to(equal(@(MTLPropertyStoragePermanent)));
 });
 
 it(@"should ignore readonly properties without backing ivar", ^{
 	expect(@([MTLStorageBehaviorModel storageBehaviorForPropertyWithKey:@"notIvarBacked"])).to(equal(@(MTLPropertyStorageNone)));
-	expect(@([MTLStorageBehaviorModelSubclass storageBehaviorForPropertyWithKey:@"notIvarBacked"])).to(equal(@(MTLPropertyStorageNone)));
 });
 
-it(@"should consider properties declared in protocol, and backed by ivar in superclass, permanent", ^{
-	expect(@([MTLStorageBehaviorModel storageBehaviorForPropertyWithKey:@"declaredInProtocol"])).to(equal(@(MTLPropertyStoragePermanent)));
+it(@"should consider properties declared in subclass with storage in superclass permanent", ^{
+	expect(@([MTLStorageBehaviorModelSubclass storageBehaviorForPropertyWithKey:@"strongProperty"])).to(equal(@(MTLPropertyStoragePermanent)));
 	expect(@([MTLStorageBehaviorModelSubclass storageBehaviorForPropertyWithKey:@"declaredInProtocol"])).to(equal(@(MTLPropertyStoragePermanent)));
 });
 

--- a/MantleTests/MTLModelSpec.m
+++ b/MantleTests/MTLModelSpec.m
@@ -137,18 +137,27 @@ it(@"should merge two models together", ^{
 
 it(@"should consider primitive properties permanent", ^{
 	expect(@([MTLStorageBehaviorModel storageBehaviorForPropertyWithKey:@"primitive"])).to(equal(@(MTLPropertyStoragePermanent)));
+	expect(@([MTLStorageBehaviorModelSubclass storageBehaviorForPropertyWithKey:@"primitive"])).to(equal(@(MTLPropertyStoragePermanent)));
 });
 
 it(@"should consider object-type assign properties permanent", ^{
 	expect(@([MTLStorageBehaviorModel storageBehaviorForPropertyWithKey:@"assignProperty"])).to(equal(@(MTLPropertyStoragePermanent)));
+	expect(@([MTLStorageBehaviorModelSubclass storageBehaviorForPropertyWithKey:@"assignProperty"])).to(equal(@(MTLPropertyStoragePermanent)));
 });
 
 it(@"should consider object-type strong properties permanent", ^{
 	expect(@([MTLStorageBehaviorModel storageBehaviorForPropertyWithKey:@"strongProperty"])).to(equal(@(MTLPropertyStoragePermanent)));
+	expect(@([MTLStorageBehaviorModelSubclass storageBehaviorForPropertyWithKey:@"strongProperty"])).to(equal(@(MTLPropertyStoragePermanent)));
 });
 
 it(@"should ignore readonly properties without backing ivar", ^{
 	expect(@([MTLStorageBehaviorModel storageBehaviorForPropertyWithKey:@"notIvarBacked"])).to(equal(@(MTLPropertyStorageNone)));
+	expect(@([MTLStorageBehaviorModelSubclass storageBehaviorForPropertyWithKey:@"notIvarBacked"])).to(equal(@(MTLPropertyStorageNone)));
+});
+
+it(@"should consider properties declared in protocol, and backed by ivar in superclass, permanent", ^{
+	expect(@([MTLStorageBehaviorModel storageBehaviorForPropertyWithKey:@"dateFromProtocol"])).to(equal(@(MTLPropertyStoragePermanent)));
+	expect(@([MTLStorageBehaviorModelSubclass storageBehaviorForPropertyWithKey:@"dateFromProtocol"])).to(equal(@(MTLPropertyStoragePermanent)));
 });
 
 describe(@"merging with model subclasses", ^{

--- a/MantleTests/MTLTestModel.h
+++ b/MantleTests/MTLTestModel.h
@@ -97,6 +97,20 @@ extern const NSInteger MTLTestModelNameMissing;
 @property (readonly, nonatomic, weak) id weakProperty;
 @property (readonly, nonatomic, strong) id strongProperty;
 
+@property (readonly, nonatomic, copy) NSDate *dateFromProtocol;
+
+@end
+
+@protocol MTLDateProtocol <NSObject>
+
+@property (readonly, nonatomic, copy) NSDate *dateFromProtocol;
+
+@end
+
+@interface MTLStorageBehaviorModelSubclass : MTLStorageBehaviorModel <MTLDateProtocol>
+
+@property (readonly, nonatomic, strong) id strongProperty; // shadows superclass without providing storage
+
 @end
 
 @interface MTLBoolModel : MTLModel <MTLJSONSerializing>

--- a/MantleTests/MTLTestModel.h
+++ b/MantleTests/MTLTestModel.h
@@ -97,13 +97,13 @@ extern const NSInteger MTLTestModelNameMissing;
 @property (readonly, nonatomic, weak) id weakProperty;
 @property (readonly, nonatomic, strong) id strongProperty;
 
-@property (readonly, nonatomic, copy) NSDate *dateFromProtocol;
+@property (readonly, nonatomic, strong) id declaredInProtocol;
 
 @end
 
 @protocol MTLDateProtocol <NSObject>
 
-@property (readonly, nonatomic, copy) NSDate *dateFromProtocol;
+@property (readonly, nonatomic, strong) id declaredInProtocol;
 
 @end
 

--- a/MantleTests/MTLTestModel.h
+++ b/MantleTests/MTLTestModel.h
@@ -97,6 +97,7 @@ extern const NSInteger MTLTestModelNameMissing;
 @property (readonly, nonatomic, weak) id weakProperty;
 @property (readonly, nonatomic, strong) id strongProperty;
 
+@property (readonly, nonatomic, strong) id shadowedInSubclass;
 @property (readonly, nonatomic, strong) id declaredInProtocol;
 
 @end
@@ -109,7 +110,7 @@ extern const NSInteger MTLTestModelNameMissing;
 
 @interface MTLStorageBehaviorModelSubclass : MTLStorageBehaviorModel <MTLDateProtocol>
 
-@property (readonly, nonatomic, strong) id strongProperty; // shadows superclass without providing storage
+@property (readonly, nonatomic, strong) id shadowedInSubclass;
 
 @end
 

--- a/MantleTests/MTLTestModel.h
+++ b/MantleTests/MTLTestModel.h
@@ -173,10 +173,13 @@ extern const NSInteger MTLTestModelNameMissing;
 @protocol MTLOptionalPropertyProtocol
 
 @optional
-@property (readwrite, nonatomic, copy) NSString *optionalProperty;
+@property (readwrite, nonatomic, strong) id optionalUnimplementedProperty;
+@property (readwrite, nonatomic, strong) id optionalImplementedProperty;
 
 @end
 
 @interface MTLOptionalPropertyModel : MTLModel <MTLOptionalPropertyProtocol>
+
+@property (readwrite, nonatomic, strong) id optionalImplementedProperty;
 
 @end

--- a/MantleTests/MTLTestModel.m
+++ b/MantleTests/MTLTestModel.m
@@ -357,7 +357,7 @@ static NSUInteger modelVersion = 1;
 
 @implementation MTLStorageBehaviorModelSubclass
 
-@dynamic strongProperty;
+@dynamic shadowedInSubclass;
 
 @end
 

--- a/MantleTests/MTLTestModel.m
+++ b/MantleTests/MTLTestModel.m
@@ -355,6 +355,12 @@ static NSUInteger modelVersion = 1;
 
 @end
 
+@implementation MTLStorageBehaviorModelSubclass
+
+@dynamic strongProperty;
+
+@end
+
 @implementation MTLMultiKeypathModel
 
 #pragma mark MTLJSONSerializing


### PR DESCRIPTION
A subclass can shadow a parent's property declaration, either explicitly
with a `@property` directive or implicitly by conforming to a protocol
that requires a particular property. The result is that the subclass
property record has no associated ivar (or methods), and calls to get /
set the property will fall up to the superclass's methods (backed by the
superclass's ivar).