### PR TITLE
Fixed MTLJsonAdapter modelOfClass: with nil dictionary passed

### DIFF
--- a/Mantle/MTLJSONAdapter.m
+++ b/Mantle/MTLJSONAdapter.m
@@ -77,9 +77,9 @@ static NSString * const MTLJSONAdapterThrownExceptionErrorKey = @"MTLJSONAdapter
 	if (JSONDictionary == nil || ![JSONDictionary isKindOfClass:NSDictionary.class]) {
 		if (error != NULL) {
 			NSDictionary *userInfo = @{
-									   NSLocalizedDescriptionKey: NSLocalizedString(@"Missing JSON dictionary", @""),
-									   NSLocalizedFailureReasonErrorKey: [NSString stringWithFormat:NSLocalizedString(@"%@ could not be created because an invalid JSON dictionary was provided: %@", @""), NSStringFromClass(modelClass), JSONDictionary.class],
-									   };
+				NSLocalizedDescriptionKey: NSLocalizedString(@"Missing JSON dictionary", @""),
+				NSLocalizedFailureReasonErrorKey: [NSString stringWithFormat:NSLocalizedString(@"%@ could not be created because an invalid JSON dictionary was provided: %@", @""), NSStringFromClass(modelClass), JSONDictionary.class],
+			};
 			*error = [NSError errorWithDomain:MTLJSONAdapterErrorDomain code:MTLJSONAdapterErrorInvalidJSONDictionary userInfo:userInfo];
 		}
 		return nil;

--- a/Mantle/MTLJSONAdapter.m
+++ b/Mantle/MTLJSONAdapter.m
@@ -74,6 +74,17 @@ static NSString * const MTLJSONAdapterThrownExceptionErrorKey = @"MTLJSONAdapter
 #pragma mark Convenience methods
 
 + (id)modelOfClass:(Class)modelClass fromJSONDictionary:(NSDictionary *)JSONDictionary error:(NSError **)error {
+	if (JSONDictionary == nil || ![JSONDictionary isKindOfClass:NSDictionary.class]) {
+		if (error != NULL) {
+			NSDictionary *userInfo = @{
+									   NSLocalizedDescriptionKey: NSLocalizedString(@"Missing JSON dictionary", @""),
+									   NSLocalizedFailureReasonErrorKey: [NSString stringWithFormat:NSLocalizedString(@"%@ could not be created because an invalid JSON dictionary was provided: %@", @""), NSStringFromClass(modelClass), JSONDictionary.class],
+									   };
+			*error = [NSError errorWithDomain:MTLJSONAdapterErrorDomain code:MTLJSONAdapterErrorInvalidJSONDictionary userInfo:userInfo];
+		}
+		return nil;
+	}
+	
 	MTLJSONAdapter *adapter = [[self alloc] initWithModelClass:modelClass];
 
 	return [adapter modelFromJSONDictionary:JSONDictionary error:error];

--- a/MantleTests/MTLJSONAdapterSpec.m
+++ b/MantleTests/MTLJSONAdapterSpec.m
@@ -59,6 +59,15 @@ it(@"should initialize with a model class", ^{
 	expect(serializationError).to(beNil());
 });
 
+it(@"should return nil and error with nil JSON dictionary",^{	
+	NSError *error = nil;
+	MTLTestModel *model = [MTLJSONAdapter modelOfClass:MTLTestModel.class fromJSONDictionary:nil error:&error];
+	expect(model).to(beNil());
+	expect(error).notTo(beNil());
+	expect(error.domain).to(equal(MTLJSONAdapterErrorDomain));
+	expect(@(error.code)).to(equal(@(MTLJSONAdapterErrorInvalidJSONDictionary)));
+});
+
 it(@"should initialize nested key paths from JSON", ^{
 	NSDictionary *values = @{
 		@"username": @"foo",


### PR DESCRIPTION
MTLJsonAdapter's method ```modelOfClass:fromJSONDictionary:error:``` called with nil-dictionary had been returning initialized object with empty fields, instead of nil as written in documentation.

This pr fixes this issue.