### PR TITLE
Lazily create MTLJSONAdapter instance to allow recursive definitions

### DIFF
--- a/Mantle/MTLJSONAdapter.m
+++ b/Mantle/MTLJSONAdapter.m
@@ -469,7 +469,7 @@ static NSString * const MTLJSONAdapterThrownExceptionErrorKey = @"MTLJSONAdapter
 + (NSValueTransformer<MTLTransformerErrorHandling> *)dictionaryTransformerWithModelClass:(Class)modelClass {
 	NSParameterAssert([modelClass isSubclassOfClass:MTLModel.class]);
 	NSParameterAssert([modelClass conformsToProtocol:@protocol(MTLJSONSerializing)]);
-	MTLJSONAdapter *adapter = [[self alloc] initWithModelClass:modelClass];
+	__block MTLJSONAdapter *adapter;
 	
 	return [MTLValueTransformer
 		transformerUsingForwardBlock:^ id (id JSONDictionary, BOOL *success, NSError **error) {
@@ -488,7 +488,10 @@ static NSString * const MTLJSONAdapterThrownExceptionErrorKey = @"MTLJSONAdapter
 				*success = NO;
 				return nil;
 			}
-			
+
+			if (!adapter) {
+				adapter = [[self alloc] initWithModelClass:modelClass];
+			}
 			id model = [adapter modelFromJSONDictionary:JSONDictionary error:error];
 			if (model == nil) {
 				*success = NO;
@@ -512,7 +515,10 @@ static NSString * const MTLJSONAdapterThrownExceptionErrorKey = @"MTLJSONAdapter
 				*success = NO;
 				return nil;
 			}
-			
+
+			if (!adapter) {
+				adapter = [[self alloc] initWithModelClass:modelClass];
+			}
 			NSDictionary *result = [adapter JSONDictionaryFromModel:model error:error];
 			if (result == nil) {
 				*success = NO;

--- a/MantleTests/MTLJSONAdapterSpec.m
+++ b/MantleTests/MTLJSONAdapterSpec.m
@@ -593,15 +593,15 @@ it(@"should not leak transformers", ^{
 
 it(@"should support recursive models", ^{
 	NSDictionary *dictionary = @{
-		@"owner": @{@"name": @"Cameron"},
+		@"owner": @{ @"name": @"Cameron" },
 		@"users": @[
-			@{@"name": @"Dimitri"},
-			@{@"name": @"John"},
+			@{ @"name": @"Dimitri" },
+			@{ @"name": @"John" },
 		],
 	};
 
 	NSError *error = nil;
-	MTLRecursiveGroupModel *group = [MTLJSONAdapter modelOfClass:[MTLRecursiveGroupModel class] fromJSONDictionary:dictionary error:&error];
+	MTLRecursiveGroupModel *group = [MTLJSONAdapter modelOfClass:MTLRecursiveGroupModel.class fromJSONDictionary:dictionary error:&error];
 	expect(group).notTo(beNil());
 	expect(@(group.users.count)).to(equal(@2));
 });

--- a/MantleTests/MTLJSONAdapterSpec.m
+++ b/MantleTests/MTLJSONAdapterSpec.m
@@ -591,4 +591,19 @@ it(@"should not leak transformers", ^{
 	expect(weakTransformer).toEventually(beNil());
 });
 
+it(@"should support recursive models", ^{
+	NSDictionary *dictionary = @{
+		@"owner": @{@"name": @"Cameron"},
+		@"users": @[
+			@{@"name": @"Dimitri"},
+			@{@"name": @"John"},
+		],
+	};
+
+	NSError *error = nil;
+	MTLRecursiveGroupModel *group = [MTLJSONAdapter modelOfClass:[MTLRecursiveGroupModel class] fromJSONDictionary:dictionary error:&error];
+	expect(group).notTo(beNil());
+	expect(@(group.users.count)).to(equal(@2));
+});
+
 QuickSpecEnd

--- a/MantleTests/MTLTestModel.h
+++ b/MantleTests/MTLTestModel.h
@@ -184,3 +184,18 @@ extern const NSInteger MTLTestModelNameMissing;
 @property (readwrite, nonatomic, strong) id optionalImplementedProperty;
 
 @end
+
+
+@interface MTLRecursiveUserModel : MTLModel <MTLJSONSerializing>
+
+@property (nonatomic, copy, readonly) NSString *name;
+@property (nonatomic, copy, readonly) NSArray *groups;
+
+@end
+
+@interface MTLRecursiveGroupModel : MTLModel <MTLJSONSerializing>
+
+@property (nonatomic, readonly) MTLRecursiveUserModel *owner;
+@property (nonatomic, readonly) NSArray *users;
+
+@end

--- a/MantleTests/MTLTestModel.m
+++ b/MantleTests/MTLTestModel.m
@@ -476,11 +476,14 @@ static NSUInteger modelVersion = 1;
 @implementation MTLRecursiveUserModel
 
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
-	return @{@"name": @"name", @"groups": @"groups"};
+	return @{
+		@"name": @"name",
+		@"groups": @"groups",
+	};
 }
 
 + (NSValueTransformer *)groupsJSONTransformer {
-	return [MTLJSONAdapter arrayTransformerWithModelClass:[MTLRecursiveGroupModel class]];
+	return [MTLJSONAdapter arrayTransformerWithModelClass:MTLRecursiveGroupModel.class];
 }
 
 @end
@@ -488,15 +491,18 @@ static NSUInteger modelVersion = 1;
 @implementation MTLRecursiveGroupModel
 
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
-	return @{@"owner": @"owner", @"users": @"users"};
+	return @{
+		@"owner": @"owner",
+		@"users": @"users",
+	};
 }
 
 + (NSValueTransformer *)ownerJSONTransformer {
-	return [MTLJSONAdapter dictionaryTransformerWithModelClass:[MTLRecursiveUserModel class]];
+	return [MTLJSONAdapter dictionaryTransformerWithModelClass:MTLRecursiveUserModel.class];
 }
 
 + (NSValueTransformer *)usersJSONTransformer {
-	return [MTLJSONAdapter arrayTransformerWithModelClass:[MTLRecursiveUserModel class]];
+	return [MTLJSONAdapter arrayTransformerWithModelClass:MTLRecursiveUserModel.class];
 }
 
 @end

--- a/MantleTests/MTLTestModel.m
+++ b/MantleTests/MTLTestModel.m
@@ -472,3 +472,31 @@ static NSUInteger modelVersion = 1;
 @implementation MTLOptionalPropertyModel
 
 @end
+
+@implementation MTLRecursiveUserModel
+
++ (NSDictionary *)JSONKeyPathsByPropertyKey {
+	return @{@"name": @"name", @"groups": @"groups"};
+}
+
++ (NSValueTransformer *)groupsJSONTransformer {
+	return [MTLJSONAdapter arrayTransformerWithModelClass:[MTLRecursiveGroupModel class]];
+}
+
+@end
+
+@implementation MTLRecursiveGroupModel
+
++ (NSDictionary *)JSONKeyPathsByPropertyKey {
+	return @{@"owner": @"owner", @"users": @"users"};
+}
+
++ (NSValueTransformer *)ownerJSONTransformer {
+	return [MTLJSONAdapter dictionaryTransformerWithModelClass:[MTLRecursiveUserModel class]];
+}
+
++ (NSValueTransformer *)usersJSONTransformer {
+	return [MTLJSONAdapter arrayTransformerWithModelClass:[MTLRecursiveUserModel class]];
+}
+
+@end


### PR DESCRIPTION
Addresses issue #581.

This will let the transformer descend the JSON dictionary and need to find that there's actually something to transform before creating the `MTLJSONAdapter` instance.

I notice that this will create multiple `MTLJSONAdapter` instances for the same model class, repeating property parsing and other lookup work. There could be further wins by caching one adapter instance for each model class (being careful to allow subclassing) — but this is a larger change that I won't do here.