### PR TITLE
Parse MTLJSONSerializing conforming property with JSONAdaptor by default

### DIFF
--- a/Mantle/MTLJSONAdapter.m
+++ b/Mantle/MTLJSONAdapter.m
@@ -405,6 +405,12 @@ static NSString * const MTLJSONAdapterThrownExceptionErrorKey = @"MTLJSONAdapter
 				transformer = [self transformerForModelPropertiesOfClass:propertyClass];
 			}
 
+
+			// For user-defined MTLModel, try parse it with dictionaryTransformer.
+			if (nil == transformer && [propertyClass conformsToProtocol:@protocol(MTLJSONSerializing)]) {
+				transformer = [self dictionaryTransformerWithModelClass:propertyClass];
+			}
+			
 			if (transformer == nil) transformer = [NSValueTransformer mtl_validatingTransformerForClass:propertyClass ?: NSObject.class];
 		} else {
 			transformer = [self transformerForModelPropertiesOfObjCType:attributes->type] ?: [NSValueTransformer mtl_validatingTransformerForClass:NSValue.class];

--- a/MantleTests/MTLJSONAdapterSpec.m
+++ b/MantleTests/MTLJSONAdapterSpec.m
@@ -606,4 +606,46 @@ it(@"should support recursive models", ^{
 	expect(@(group.users.count)).to(equal(@2));
 });
 
+it(@"should initialize a MTLJSONSerializingProperty with MTLJSONAdapter by default", ^{
+	NSDictionary *JSONDictionary = @{
+		@"property": @"property0",
+		@"conformingMTLJSONSerializingProperty":@{
+				@"username": @"testName",
+				@"count": @"5",
+		}
+	};
+
+	MTLJSONAdapter *adapter = [[MTLJSONAdapter alloc] initWithModelClass:MTLPropertyDefaultAdaptorModel.class];
+	expect(adapter).notTo(beNil());
+
+	NSError *error = nil;
+	MTLPropertyDefaultAdaptorModel *model = [MTLJSONAdapter modelOfClass:MTLPropertyDefaultAdaptorModel.class fromJSONDictionary:JSONDictionary error:&error];
+	expect(error).to(beNil());
+	expect(model).notTo(beNil());
+	expect(model.property).to(equal(@"property0"));
+	expect(model.conformingMTLJSONSerializingProperty).notTo(beNil());
+	expect(model.conformingMTLJSONSerializingProperty.name).to(equal(@"testName"));
+});
+
+it(@"should only initialize a MTLJSONSerializingProperty with MTLJSONAdaptor by default, not MTLModel", ^{
+	NSDictionary *JSONDictionary = @{
+		@"property": @"property0",
+		@"conformingMTLJSONSerializingProperty":@{
+					@"username": @"testName",
+					@"count": @"5",
+		},
+		@"nonConformingMTLJSONSerializingProperty": @{}// should not be parsed correctly
+	};
+
+	MTLJSONAdapter *adapter = [[MTLJSONAdapter alloc] initWithModelClass:MTLPropertyDefaultAdaptorModel.class];
+	expect(adapter).notTo(beNil());
+
+	NSError *error = nil;
+	MTLPropertyDefaultAdaptorModel *model = [adapter modelFromJSONDictionary:JSONDictionary error:&error];
+	expect(error).notTo(beNil());
+	
+	expect(model).to(beNil());
+
+});
+
 QuickSpecEnd

--- a/MantleTests/MTLTestModel.h
+++ b/MantleTests/MTLTestModel.h
@@ -197,5 +197,13 @@ extern const NSInteger MTLTestModelNameMissing;
 
 @property (nonatomic, readonly) MTLRecursiveUserModel *owner;
 @property (nonatomic, readonly) NSArray *users;
+@end
+
+// This is for testing parsing MTLJSONSerializing property by default.
+@interface MTLPropertyDefaultAdaptorModel : MTLModel<MTLJSONSerializing>
+
+@property (nonatomic, strong) NSString *property;
+@property (nonatomic, strong) MTLTestModel *conformingMTLJSONSerializingProperty;
+@property (nonatomic, strong) MTLEmptyTestModel *nonConformingMTLJSONSerializingProperty;
 
 @end

--- a/MantleTests/MTLTestModel.m
+++ b/MantleTests/MTLTestModel.m
@@ -506,3 +506,15 @@ static NSUInteger modelVersion = 1;
 }
 
 @end
+
+@implementation MTLPropertyDefaultAdaptorModel
+
++ (NSDictionary *)JSONKeyPathsByPropertyKey {
+	return @{
+				@"property": @"property",
+				@"conformingMTLJSONSerializingProperty": @"conformingMTLJSONSerializingProperty",
+				@"nonConformingMTLJSONSerializingProperty": @"nonConformingMTLJSONSerializingProperty"
+			};;
+}
+
+@end


### PR DESCRIPTION
Parse MTLJSONSerializing conforming property with JSONAdaptor by default