### PR TITLE
Xcode 7 really wants to run these upgrade checks.

### DIFF
--- a/Mantle.xcodeproj/project.pbxproj
+++ b/Mantle.xcodeproj/project.pbxproj
@@ -654,6 +654,7 @@
 		D042FC3215F72B23004E8054 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				LastSwiftUpdateCheck = 0700;
 				LastTestingUpgradeCheck = 0510;
 				LastUpgradeCheck = 0620;
 				ORGANIZATIONNAME = GitHub;


### PR DESCRIPTION
Letting Xcode do its thing with the upgrade checks. I didn't actually convert anything, the tests need to be converted to Swift 2 if that's something that should actually be done.