### PR TITLE
Add NSFormatter value transformer additions

### DIFF
--- a/Mantle/NSValueTransformer+MTLPredefinedTransformerAdditions.h
+++ b/Mantle/NSValueTransformer+MTLPredefinedTransformerAdditions.h
@@ -63,6 +63,42 @@ extern NSString * const MTLBooleanValueTransformerName;
 /// with a default value of `nil` and a reverse default value of `nil`.
 + (NSValueTransformer<MTLTransformerErrorHandling> *)mtl_valueMappingTransformerWithDictionary:(NSDictionary *)dictionary;
 
+/// A reversible value transformer to transform between a date and its string
+/// representation
+///
+/// dateFormat - The date format used by the date formatter (http://www.unicode.org/reports/tr35/tr35-31/tr35-dates.html#Date_Field_Symbol_Table)
+/// calendar   - The calendar used by the date formatter
+/// locale     - The locale used by the date formatter
+/// timeZone   - The time zone used by the date formatter
+///
+/// Returns a transformer which will map from strings to dates for forward
+/// transformations, and from dates to strings for reverse transformations.
++ (NSValueTransformer<MTLTransformerErrorHandling> *)mtl_dateTransformerWithDateFormat:(NSString *)dateFormat calendar:(NSCalendar *)calendar locale:(NSLocale *)locale timeZone:(NSTimeZone *)timeZone defaultDate:(NSDate *)defaultDate;
+
+/// Returns a value transformer created by calling
+/// `+mtl_dateTransformerWithDateFormat:calendar:locale:timeZone:defaultDate:`
+/// with a calendar, locale, time zone and default date of `nil`.
++ (NSValueTransformer<MTLTransformerErrorHandling> *)mtl_dateTransformerWithDateFormat:(NSString *)dateFormat locale:(NSLocale *)locale;
+
+/// A reversible value transformer to transform between a number and its string
+/// representation
+///
+/// numberStyle - The number style used by the number formatter
+///
+/// Returns a transformer which will map from strings to numbers for forward
+/// transformations, and from numbers to strings for reverse transformations.
++ (NSValueTransformer<MTLTransformerErrorHandling> *)mtl_numberTransformerWithNumberStyle:(NSNumberFormatterStyle)numberStyle locale:(NSLocale *)locale;
+
+/// A reversible value transformer to transform between an object and its string
+/// representation
+///
+/// formatter   - The formatter used to perform the transformation
+/// objectClass - The class of object that the formatter operates on
+///
+/// Returns a transformer which will map from strings to objects for forward
+/// transformations, and from objects to strings for reverse transformations.
++ (NSValueTransformer<MTLTransformerErrorHandling> *)mtl_transformerWithFormatter:(NSFormatter *)formatter forObjectClass:(Class)objectClass;
+
 /// A value transformer that errors if the transformed value are not of the given
 /// class.
 ///

--- a/Mantle/NSValueTransformer+MTLPredefinedTransformerAdditions.m
+++ b/Mantle/NSValueTransformer+MTLPredefinedTransformerAdditions.m
@@ -275,6 +275,108 @@ NSString * const MTLBooleanValueTransformerName = @"MTLBooleanValueTransformerNa
 	return [self mtl_valueMappingTransformerWithDictionary:dictionary defaultValue:nil reverseDefaultValue:nil];
 }
 
++ (NSValueTransformer<MTLTransformerErrorHandling> *)mtl_dateTransformerWithDateFormat:(NSString *)dateFormat calendar:(NSCalendar *)calendar locale:(NSLocale *)locale timeZone:(NSTimeZone *)timeZone defaultDate:(NSDate *)defaultDate {
+	NSParameterAssert(dateFormat.length);
+
+	NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
+	dateFormatter.dateFormat = dateFormat;
+	dateFormatter.calendar = calendar;
+	dateFormatter.locale = locale;
+	dateFormatter.timeZone = timeZone;
+	dateFormatter.defaultDate = defaultDate;
+
+	return [NSValueTransformer mtl_transformerWithFormatter:dateFormatter forObjectClass:NSDate.class];
+}
+
+
++ (NSValueTransformer<MTLTransformerErrorHandling> *)mtl_dateTransformerWithDateFormat:(NSString *)dateFormat locale:(NSLocale *)locale {
+	return [self mtl_dateTransformerWithDateFormat:dateFormat calendar:nil locale:locale timeZone:nil defaultDate:nil];
+}
+
++ (NSValueTransformer<MTLTransformerErrorHandling> *)mtl_numberTransformerWithNumberStyle:(NSNumberFormatterStyle)numberStyle locale:(NSLocale *)locale {
+	NSNumberFormatter *numberFormatter = [[NSNumberFormatter alloc] init];
+	numberFormatter.numberStyle = numberStyle;
+	numberFormatter.locale = locale;
+
+	return [self mtl_transformerWithFormatter:numberFormatter forObjectClass:NSNumber.class];
+}
+
++ (NSValueTransformer<MTLTransformerErrorHandling> *)mtl_transformerWithFormatter:(NSFormatter *)formatter forObjectClass:(Class)objectClass {
+	NSParameterAssert(formatter != nil);
+	NSParameterAssert(objectClass != nil);
+	return [MTLValueTransformer
+			transformerUsingForwardBlock:^ id (NSString *str, BOOL *success, NSError *__autoreleasing *error) {
+				if (str == nil) return nil;
+
+				if (![str isKindOfClass:NSString.class]) {
+					if (error != NULL) {
+						NSDictionary *userInfo = @{
+						    NSLocalizedDescriptionKey: [NSString stringWithFormat:NSLocalizedString(@"Could not convert string to %@", @""), objectClass],
+							NSLocalizedFailureReasonErrorKey: [NSString stringWithFormat:NSLocalizedString(@"Expected an NSString as input, got: %@.", @""), str],
+							MTLTransformerErrorHandlingInputValueErrorKey : str
+						};
+						
+						*error = [NSError errorWithDomain:MTLTransformerErrorHandlingErrorDomain code:MTLTransformerErrorHandlingErrorInvalidInput userInfo:userInfo];
+					}
+					*success = NO;
+					return nil;
+				}
+
+				id object = nil;
+				NSString *errorDescription = nil;
+				*success = [formatter getObjectValue:&object forString:str errorDescription:&errorDescription];
+
+				if (errorDescription != nil) {
+					if (error != NULL) {
+						NSDictionary *userInfo = @{
+							NSLocalizedDescriptionKey: [NSString stringWithFormat:NSLocalizedString(@"Could not convert string to %@", @""), objectClass],
+							NSLocalizedFailureReasonErrorKey: errorDescription,
+							MTLTransformerErrorHandlingInputValueErrorKey : str
+						};
+						
+						*error = [NSError errorWithDomain:MTLTransformerErrorHandlingErrorDomain code:MTLTransformerErrorHandlingErrorInvalidInput userInfo:userInfo];
+					}
+					*success = NO;
+					return nil;
+				}
+
+				if (![object isKindOfClass:objectClass]) {
+					if (error != NULL) {
+						NSDictionary *userInfo = @{
+							NSLocalizedDescriptionKey: [NSString stringWithFormat:NSLocalizedString(@"Could not convert string to %@", @""), objectClass],
+							NSLocalizedFailureReasonErrorKey: [NSString stringWithFormat:NSLocalizedString(@"Expected an %@ as output from the formatter, got: %@.", @""), objectClass, object],
+						};
+
+						*error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSFormattingError userInfo:userInfo];
+					}
+					*success = NO;
+					return nil;
+				}
+
+				return object;
+			} reverseBlock:^id(id object, BOOL *success, NSError *__autoreleasing *error) {
+				if (object == nil) return nil;
+
+				if (![object isKindOfClass:objectClass]) {
+					if (error != NULL) {
+						NSDictionary *userInfo = @{
+						   NSLocalizedDescriptionKey: [NSString stringWithFormat:NSLocalizedString(@"Could not convert %@ to string", @""), objectClass],
+						   NSLocalizedFailureReasonErrorKey: [NSString stringWithFormat:NSLocalizedString(@"Expected an %@ as input, got: %@.", @""), objectClass, object],
+						   MTLTransformerErrorHandlingInputValueErrorKey : object
+						};
+
+						*error = [NSError errorWithDomain:MTLTransformerErrorHandlingErrorDomain code:MTLTransformerErrorHandlingErrorInvalidInput userInfo:userInfo];
+					}
+					*success = NO;
+					return nil;
+				}
+
+				NSString *string = [formatter stringForObjectValue:object];
+				*success = (string != nil);
+				return string;
+			}];
+}
+
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-implementations"
 

--- a/MantleTests/MTLPredefinedTransformerAdditionsSpec.m
+++ b/MantleTests/MTLPredefinedTransformerAdditionsSpec.m
@@ -193,4 +193,84 @@ describe(@"value mapping transformer", ^{
 	});
 });
 
+describe(@"date format transformer", ^{
+	__block NSValueTransformer<MTLTransformerErrorHandling> *transformer;
+
+	beforeEach(^{
+		transformer = [NSValueTransformer mtl_dateTransformerWithDateFormat:@"MMMM d, yyyy" calendar:[NSCalendar calendarWithIdentifier:NSCalendarIdentifierGregorian] locale:[NSLocale localeWithLocaleIdentifier:@"en_US"] timeZone:[NSTimeZone timeZoneWithName:@"America/Los_Angeles"] defaultDate:nil];
+		expect(transformer).notTo(beNil());
+		expect(@([transformer.class allowsReverseTransformation])).to(beTruthy());
+		expect([transformer transformedValue:nil]).to(beNil());
+		expect([transformer reverseTransformedValue:nil]).to(beNil());
+	});
+
+	it(@"should transform strings into dates", ^{
+		expect([transformer transformedValue:@"September 25, 2015"]).to(equal([NSDate dateWithTimeIntervalSince1970:1443164400]));
+	});
+
+	it(@"should transform dates into strings", ^{
+		expect([transformer reverseTransformedValue:[NSDate dateWithTimeIntervalSince1970:1183135260]]).to(equal(@"June 29, 2007"));
+	});
+
+	it(@"should surface date formatter error descriptions", ^{
+		__block NSError *error;
+		__block BOOL success = NO;
+		
+		expect([transformer transformedValue:@"September 37, 2015" success:&success error:&error]).to(beNil());
+		expect(@(success)).to(beFalsy());
+		expect(error).notTo(beNil());
+		expect(error.domain).to(equal(MTLTransformerErrorHandlingErrorDomain));
+		expect(@(error.code)).to(equal(@(MTLTransformerErrorHandlingErrorInvalidInput)));
+		expect(error.userInfo[NSLocalizedFailureReasonErrorKey]).notTo(beNil());
+	});
+
+	itBehavesLike(MTLTransformerErrorExamples, ^{
+		return @{
+			MTLTransformerErrorExamplesTransformer: transformer,
+			MTLTransformerErrorExamplesInvalidTransformationInput: NSNull.null,
+			MTLTransformerErrorExamplesInvalidReverseTransformationInput: NSNull.null
+		};
+	});
+});
+
+describe(@"number format transformer", ^{
+	__block NSValueTransformer<MTLTransformerErrorHandling> *transformer;
+
+	beforeEach(^{
+		transformer = [NSValueTransformer mtl_numberTransformerWithNumberStyle:NSNumberFormatterDecimalStyle locale:[NSLocale localeWithLocaleIdentifier:@"en_US"]];
+		expect(transformer).notTo(beNil());
+		expect(@([transformer.class allowsReverseTransformation])).to(beTruthy());
+		expect([transformer transformedValue:nil]).to(beNil());
+		expect([transformer reverseTransformedValue:nil]).to(beNil());
+	});
+
+	it(@"should transform strings into numbers", ^{
+		expect([transformer transformedValue:@"0.12345"]).to(equal(@0.12345));
+	});
+
+	it(@"should transform numbers into strings", ^{
+		expect([transformer reverseTransformedValue:@12345.678]).to(equal(@"12,345.678"));
+	});
+
+	it(@"should surface number formatter error descriptions", ^{
+		__block NSError *error;
+		__block BOOL success = NO;
+
+		expect([transformer transformedValue:@"Apple" success:&success error:&error]).to(beNil());
+		expect(@(success)).to(beFalsy());
+		expect(error).notTo(beNil());
+		expect(error.domain).to(equal(MTLTransformerErrorHandlingErrorDomain));
+		expect(@(error.code)).to(equal(@(MTLTransformerErrorHandlingErrorInvalidInput)));
+		expect(error.userInfo[NSLocalizedFailureReasonErrorKey]).notTo(beNil());
+	});
+
+	itBehavesLike(MTLTransformerErrorExamples, ^{
+		return @{
+			MTLTransformerErrorExamplesTransformer: transformer,
+			MTLTransformerErrorExamplesInvalidTransformationInput: NSNull.null,
+			MTLTransformerErrorExamplesInvalidReverseTransformationInput: NSNull.null
+		};
+	});
+});
+
 QuickSpecEnd


### PR DESCRIPTION
While working on [Workflow](https://workflow.is), I consume a lot of JSON APIs, and there are consistently values that I need to write my own transformers for: dates and numbers.

I find myself creating `NSDateFormatter`/ `NSNumberFormatter`/ `-[NSString doubleValue]`-based `MTLValueTransformer`s very frequently, so I decided to add the functionality into Mantle itself. When I am writing these quick, one-off transformers I often don't write them properly: I don't bother to handle errors or validate types.

I made a new transformer factory method based on `NSFormatter`, which is the common superclass to both `NSDateFormatter` and `NSNumberFormatter`.

Let me know what you think!