### PR TITLE
Backported "faster method calls" to 1.x

### DIFF
--- a/Mantle.xcodeproj/xcshareddata/xcschemes/Mantle Mac.xcscheme
+++ b/Mantle.xcodeproj/xcshareddata/xcschemes/Mantle Mac.xcscheme
@@ -40,7 +40,7 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
-      buildConfiguration = "Debug">
+      buildConfiguration = "Release">
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/Mantle/MTLJSONAdapter.m
+++ b/Mantle/MTLJSONAdapter.m
@@ -276,8 +276,8 @@ static NSString * const MTLJSONAdapterThrownExceptionErrorKey = @"MTLJSONAdapter
 	SEL selector = MTLSelectorWithKeyPattern(key, "JSONTransformer");
 	if ([self.modelClass respondsToSelector:selector]) {
 		IMP imp = [self.modelClass methodForSelector:selector];
-		NSValueTransformer * (*function)(id, SEL) = (NSValueTransformer * (*)(id, SEL))imp;
-		__unsafe_unretained NSValueTransformer *transformer = function(self.modelClass, selector);
+		NSValueTransformer * (*function)(id, SEL) = (__typeof__(function))imp;
+		NSValueTransformer *transformer = function(self.modelClass, selector);
 		return transformer;
 	}
 

--- a/Mantle/MTLJSONAdapter.m
+++ b/Mantle/MTLJSONAdapter.m
@@ -275,14 +275,10 @@ static NSString * const MTLJSONAdapterThrownExceptionErrorKey = @"MTLJSONAdapter
 
 	SEL selector = MTLSelectorWithKeyPattern(key, "JSONTransformer");
 	if ([self.modelClass respondsToSelector:selector]) {
-		NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:[self.modelClass methodSignatureForSelector:selector]];
-		invocation.target = self.modelClass;
-		invocation.selector = selector;
-		[invocation invoke];
-
-		__unsafe_unretained id result = nil;
-		[invocation getReturnValue:&result];
-		return result;
+		IMP imp = [self.modelClass methodForSelector:selector];
+		NSValueTransformer * (*function)(id, SEL) = (NSValueTransformer * (*)(id, SEL))imp;
+		__unsafe_unretained NSValueTransformer *transformer = function(self.modelClass, selector);
+		return transformer;
 	}
 
 	if ([self.modelClass respondsToSelector:@selector(JSONTransformerForKey:)]) {

--- a/Mantle/MTLManagedObjectAdapter.m
+++ b/Mantle/MTLManagedObjectAdapter.m
@@ -572,8 +572,8 @@ static id performInContext(NSManagedObjectContext *context, id (^block)(void)) {
 	SEL selector = MTLSelectorWithKeyPattern(key, "EntityAttributeTransformer");
 	if ([self.modelClass respondsToSelector:selector]) {
 		IMP imp = [self.modelClass methodForSelector:selector];
-		NSValueTransformer * (*function)(id, SEL) = (NSValueTransformer * (*)(id, SEL))imp;
-		__unsafe_unretained NSValueTransformer *transformer = function(self.modelClass, selector);
+		NSValueTransformer * (*function)(id, SEL) = (__typeof__(function))imp;
+		NSValueTransformer *transformer = function(self.modelClass, selector);
 		return transformer;
 	}
 

--- a/Mantle/MTLManagedObjectAdapter.m
+++ b/Mantle/MTLManagedObjectAdapter.m
@@ -571,14 +571,10 @@ static id performInContext(NSManagedObjectContext *context, id (^block)(void)) {
 
 	SEL selector = MTLSelectorWithKeyPattern(key, "EntityAttributeTransformer");
 	if ([self.modelClass respondsToSelector:selector]) {
-		NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:[self.modelClass methodSignatureForSelector:selector]];
-		invocation.target = self.modelClass;
-		invocation.selector = selector;
-		[invocation invoke];
-
-		__unsafe_unretained id result = nil;
-		[invocation getReturnValue:&result];
-		return result;
+		IMP imp = [self.modelClass methodForSelector:selector];
+		NSValueTransformer * (*function)(id, SEL) = (NSValueTransformer * (*)(id, SEL))imp;
+		__unsafe_unretained NSValueTransformer *transformer = function(self.modelClass, selector);
+		return transformer;
 	}
 
 	if ([self.modelClass respondsToSelector:@selector(entityAttributeTransformerForKey:)]) {

--- a/Mantle/MTLModel+NSCoding.m
+++ b/Mantle/MTLModel+NSCoding.m
@@ -130,8 +130,8 @@ static void verifyAllowedClassesByPropertyKey(Class modelClass) {
 	SEL selector = MTLSelectorWithCapitalizedKeyPattern("decode", key, "WithCoder:modelVersion:");
 	if ([self respondsToSelector:selector]) {
 		IMP imp = [self methodForSelector:selector];
-		id (*function)(id, SEL, NSCoder *, NSUInteger) = (id (*)(id, SEL, NSCoder *, NSUInteger))imp;
-		__unsafe_unretained id result = function(self, selector, coder, modelVersion);
+		id (*function)(id, SEL, NSCoder *, NSUInteger) = (__typeof__(function))imp;
+		id result = function(self, selector, coder, modelVersion);
 		
 		return result;
 	}

--- a/Mantle/MTLModel+NSCoding.m
+++ b/Mantle/MTLModel+NSCoding.m
@@ -129,15 +129,10 @@ static void verifyAllowedClassesByPropertyKey(Class modelClass) {
 
 	SEL selector = MTLSelectorWithCapitalizedKeyPattern("decode", key, "WithCoder:modelVersion:");
 	if ([self respondsToSelector:selector]) {
-		NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:[self methodSignatureForSelector:selector]];
-		invocation.target = self;
-		invocation.selector = selector;
-		[invocation setArgument:&coder atIndex:2];
-		[invocation setArgument:&modelVersion atIndex:3];
-		[invocation invoke];
-
-		__unsafe_unretained id result = nil;
-		[invocation getReturnValue:&result];
+		IMP imp = [self methodForSelector:selector];
+		id (*function)(id, SEL, NSCoder *, NSUInteger) = (id (*)(id, SEL, NSCoder *, NSUInteger))imp;
+		__unsafe_unretained id result = function(self, selector, coder, modelVersion);
+		
 		return result;
 	}
 

--- a/Mantle/MTLModel.m
+++ b/Mantle/MTLModel.m
@@ -175,12 +175,9 @@ static BOOL MTLValidateAndSetValue(id obj, NSString *key, id value, BOOL forceUp
 		return;
 	}
 
-	NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:[self methodSignatureForSelector:selector]];
-	invocation.target = self;
-	invocation.selector = selector;
-
-	[invocation setArgument:&model atIndex:2];
-	[invocation invoke];
+	IMP imp = [self methodForSelector:selector];
+	void (*function)(id, SEL, MTLModel *) = (void (*)(id, SEL, MTLModel *))imp;
+	function(self, selector, model);
 }
 
 - (void)mergeValuesForKeysFromModel:(MTLModel *)model {

--- a/Mantle/MTLModel.m
+++ b/Mantle/MTLModel.m
@@ -176,7 +176,7 @@ static BOOL MTLValidateAndSetValue(id obj, NSString *key, id value, BOOL forceUp
 	}
 
 	IMP imp = [self methodForSelector:selector];
-	void (*function)(id, SEL, MTLModel *) = (void (*)(id, SEL, MTLModel *))imp;
+	void (*function)(id, SEL, MTLModel *) = (__typeof__(function))imp;
 	function(self, selector, model);
 }
 

--- a/MantleTests/MTLJSONAdapterSpec.m
+++ b/MantleTests/MTLJSONAdapterSpec.m
@@ -12,6 +12,21 @@
 
 #import "MTLTestModel.h"
 
+@interface MTLJSONAdapter (SpecExtensions)
+
+// Used for testing transformer lifetimes.
++ (NSValueTransformer *)NSDateJSONTransformer;
+
+@end
+
+@implementation MTLJSONAdapter (SpecExtensions)
+
++ (NSValueTransformer *)NSDateJSONTransformer {
+	return [[NSValueTransformer alloc] init];
+}
+
+@end
+
 QuickSpecBegin(MTLJSONAdapterSpec)
 
 it(@"should initialize from JSON", ^{
@@ -278,5 +293,17 @@ it(@"should return an array of dictionaries from models", ^{
 	expect(JSONArray[1][@"username"]).to(equal(@"bar"));
 });
 
+it(@"should not leak transformers", ^{
+	__weak id weakTransformer;
+
+	@autoreleasepool {
+		id transformer = [MTLJSONAdapter transformerForModelPropertiesOfClass:NSDate.class];
+		weakTransformer = transformer;
+
+		expect(transformer).notTo(beNil());
+	}
+
+	expect(weakTransformer).toEventually(beNil());
+});
 
 QuickSpecEnd

--- a/MantleTests/MTLJSONAdapterSpec.m
+++ b/MantleTests/MTLJSONAdapterSpec.m
@@ -15,15 +15,7 @@
 @interface MTLJSONAdapter (SpecExtensions)
 
 // Used for testing transformer lifetimes.
-+ (NSValueTransformer *)NSDateJSONTransformer;
-
-@end
-
-@implementation MTLJSONAdapter (SpecExtensions)
-
-+ (NSValueTransformer *)NSDateJSONTransformer {
-	return [[NSValueTransformer alloc] init];
-}
+- (NSValueTransformer *)JSONTransformerForKey:(NSString *)key;
 
 @end
 
@@ -294,10 +286,13 @@ it(@"should return an array of dictionaries from models", ^{
 });
 
 it(@"should not leak transformers", ^{
+	MTLTestModel *model = [[MTLTestModel alloc] init];
+	MTLJSONAdapter *adapter = [[MTLJSONAdapter alloc] initWithModel:model];
+
 	__weak id weakTransformer;
 
 	@autoreleasepool {
-		id transformer = [MTLJSONAdapter transformerForModelPropertiesOfClass:NSDate.class];
+		id transformer = [adapter JSONTransformerForKey:@"count"];
 		weakTransformer = transformer;
 
 		expect(transformer).notTo(beNil());


### PR DESCRIPTION
This backports the performance improvements from #520 (and correseponding fix from #525) to the 1.x maintenance branch.

In my scenario object graphs are rather large and so i wanted to profit from the remarkable improvement by @adamkaplan but on the other hand i still have to support iOS 6.