### PR TITLE
Fix random test case failure

### DIFF
--- a/MantleTests/MTLPredefinedTransformerAdditionsSpec.m
+++ b/MantleTests/MTLPredefinedTransformerAdditionsSpec.m
@@ -103,12 +103,6 @@ describe(@"+mtl_arrayMappingTransformerWithTransformer:", ^{
 		[NSURL URLWithString:@"https://github.com/MantleFramework"],
 		[NSURL URLWithString:@"http://apple.com"]
 	];
-	
-	beforeEach(^{
-		NSValueTransformer *appliedTransformer = [NSValueTransformer valueTransformerForName:MTLURLValueTransformerName];
-		transformer = [NSValueTransformer mtl_arrayMappingTransformerWithTransformer:appliedTransformer];
-		expect(transformer).notTo(beNil());
-	});
 
 	describe(@"when called with a reversible transformer", ^{
 		beforeEach(^{
@@ -148,6 +142,12 @@ describe(@"+mtl_arrayMappingTransformerWithTransformer:", ^{
 		});
 	});
 
+	beforeEach(^{
+		NSValueTransformer *appliedTransformer = [NSValueTransformer valueTransformerForName:MTLURLValueTransformerName];
+		transformer = [NSValueTransformer mtl_arrayMappingTransformerWithTransformer:appliedTransformer];
+		expect(transformer).notTo(beNil());
+	});
+	
 	itBehavesLike(MTLTransformerErrorExamples, ^{
 		return @{
 			MTLTransformerErrorExamplesTransformer: transformer,

--- a/MantleTests/MTLPredefinedTransformerAdditionsSpec.m
+++ b/MantleTests/MTLPredefinedTransformerAdditionsSpec.m
@@ -103,6 +103,12 @@ describe(@"+mtl_arrayMappingTransformerWithTransformer:", ^{
 		[NSURL URLWithString:@"https://github.com/MantleFramework"],
 		[NSURL URLWithString:@"http://apple.com"]
 	];
+	
+	beforeEach(^{
+		NSValueTransformer *appliedTransformer = [NSValueTransformer valueTransformerForName:MTLURLValueTransformerName];
+		transformer = [NSValueTransformer mtl_arrayMappingTransformerWithTransformer:appliedTransformer];
+		expect(transformer).notTo(beNil());
+	});
 
 	describe(@"when called with a reversible transformer", ^{
 		beforeEach(^{


### PR DESCRIPTION
Test cases are failing **randomly** with error message

``` objective-c
Assertions: failed: caught "NSInvalidArgumentException", "*** -[__NSPlaceholderDictionary initWithObjects:forKeys:count:]: attempt to insert nil object from objects[0]"
.
.
<-Call Stack->
.
.
File: MTLPredefinedTransformerAdditionsSpec.m:146
```

Issue is, the transformer is `nil` when dictionary is being created in `itBehavesLike` call of `+mtl_arrayMappingTransformerWithTransformer:` description

I guess, the randomness is caused due to inner `beforeEach`s getting called before `itBehavesLike`, setting the transformer value.

Fixed it by adding a `beforeEach` block at `itBehavesLike` level.
