### PR TITLE
Made automatic NSURL transfom to work even if JSONTransformerForKey method defined

### DIFF
--- a/Mantle/MTLJSONAdapter.m
+++ b/Mantle/MTLJSONAdapter.m
@@ -383,10 +383,10 @@ NSString * const MTLJSONAdapterThrownExceptionErrorKey = @"MTLJSONAdapterThrownE
 		if ([modelClass respondsToSelector:@selector(JSONTransformerForKey:)]) {
 			NSValueTransformer *transformer = [modelClass JSONTransformerForKey:key];
 
-            if (transformer != nil) {
-                result[key] = transformer;
-                continue;
-            }
+			if (transformer != nil) {
+				result[key] = transformer;
+				continue;
+			}
 		}
 
 		objc_property_t property = class_getProperty(modelClass, key.UTF8String);

--- a/Mantle/MTLJSONAdapter.m
+++ b/Mantle/MTLJSONAdapter.m
@@ -383,9 +383,10 @@ NSString * const MTLJSONAdapterThrownExceptionErrorKey = @"MTLJSONAdapterThrownE
 		if ([modelClass respondsToSelector:@selector(JSONTransformerForKey:)]) {
 			NSValueTransformer *transformer = [modelClass JSONTransformerForKey:key];
 
-			if (transformer != nil) result[key] = transformer;
-
-			continue;
+            if (transformer != nil) {
+                result[key] = transformer;
+                continue;
+            }
 		}
 
 		objc_property_t property = class_getProperty(modelClass, key.UTF8String);

--- a/MantleTests/MTLJSONAdapterSpec.m
+++ b/MantleTests/MTLJSONAdapterSpec.m
@@ -193,6 +193,19 @@ it(@"should fail to initialize if JSON dictionary validation fails", ^{
 	expect(@(error.code)).to(equal(@(MTLTestModelNameTooLong)));
 });
 
+it(@"should implicitly transform NSStrings to URLs", ^{
+	NSDictionary *values = @{
+		@"URL": @"http://github.com/1",
+		@"otherURL": @"http://github.com/2",
+	};
+	
+	NSError *error = nil;
+	MTLURLSubclassModel *model = [MTLJSONAdapter modelOfClass:MTLURLSubclassModel.class fromJSONDictionary:values error:&error];
+	expect(model.URL).to(equal([NSURL URLWithString:@"http://github.com/1"]));
+	expect(model.otherURL).to(equal([NSURL URLWithString:@"http://github.com/2"]));
+	expect(error).to(beNil());
+});
+
 it(@"should implicitly transform URLs", ^{
 	MTLURLModel *model = [[MTLURLModel alloc] init];
 

--- a/MantleTests/MTLTestModel.h
+++ b/MantleTests/MTLTestModel.h
@@ -82,6 +82,13 @@ extern const NSInteger MTLTestModelNameMissing;
 
 @end
 
+@interface MTLURLSubclassModel : MTLURLModel
+
+// Defaults to http://github.com/Mantle/Mantle.
+@property (nonatomic, strong) NSURL *otherURL;
+
+@end
+
 // Conforms to MTLJSONSerializing but does not inherit from the MTLModel class.
 @interface MTLConformingModel : NSObject <MTLJSONSerializing>
 

--- a/MantleTests/MTLTestModel.m
+++ b/MantleTests/MTLTestModel.m
@@ -215,6 +215,25 @@ static NSUInteger modelVersion = 1;
 
 @end
 
+@implementation MTLURLSubclassModel
+
+- (instancetype)init {
+	self = [super init];
+	if (self == nil) return nil;
+	
+	self.otherURL = [NSURL URLWithString:@"http://github.com/Mantle/Mantle"];
+	return self;
+}
+
++ (NSValueTransformer *)JSONTransformerForKey:(NSString *)key {
+	return @{
+		// Not provided transformer for self.URL
+		@"otherURL": [NSValueTransformer valueTransformerForName:MTLURLValueTransformerName],
+	}[key];
+}
+
+@end
+
 @implementation MTLBoolModel
 
 + (NSDictionary *)JSONKeyPathsByPropertyKey {


### PR DESCRIPTION
This works nice:
```objective-c
@interface Video
@property (strong, nonatomic) NSURL *streamUrl;
@property (strong, nonatomic) Money *cost;
@end

@implementation Video
+ (NSValueTransformer *)costJSONTransformer {
    return [MTLValueTransformer transformerUsingForwardBlock:^id(id value, BOOL *success, NSError *__autoreleasing *error) {
        return [MTLJSONAdapter modelOfClass:[Money class] fromJSONDictionary:value error:nil];
    }];
}
@end
```

But this gives and NSURL transform error:
```objective-c
#import <libextobjc/extobjc.h>

@interface Video
@property (strong, nonatomic) NSURL *streamUrl;
@property (strong, nonatomic) Money *cost;
@end

@implementation Video
+ (NSValueTransformer *)JSONTransformerForKey:(NSString *)key {
    MTLValueTransformer *costTransformer = [MTLValueTransformer transformerUsingForwardBlock:^id(id value, BOOL *success, NSError *__autoreleasing *error) {
        return [MTLJSONAdapter modelOfClass:[Money class] fromJSONDictionary:value error:nil];
    }];
    
    return @{
        @keypath(Video.new, cost): costTransformer,
    }[key];
}
@end
```

Solution is to add this line:
```objective-c
@keypath(Video.new, streamUrl): [NSValueTransformer valueTransformerForName:MTLURLValueTransformerName],
```

But I really like automatic NSURL/BOOL transforming. Why it should not work when method `JSONTransformerForKey:` is defined?