### PR TITLE
Added runtime tests

### DIFF
--- a/Mantle.xcodeproj/project.pbxproj
+++ b/Mantle.xcodeproj/project.pbxproj
@@ -10,6 +10,11 @@
 		1ED5B5CC163A4E2B0072668E /* MTLComparisonAdditionsSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 1ED5B5CB163A4E2B0072668E /* MTLComparisonAdditionsSpec.m */; };
 		1ED5B5D0163A4E3C0072668E /* NSObject+MTLComparisonAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 1ED5B5CE163A4E3C0072668E /* NSObject+MTLComparisonAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		1ED5B5D1163A4E3C0072668E /* NSObject+MTLComparisonAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 1ED5B5CF163A4E3C0072668E /* NSObject+MTLComparisonAdditions.m */; };
+		256D00E41C92C3E60075F4F7 /* MTLRuntimeRoutines.h in Headers */ = {isa = PBXBuildFile; fileRef = 256D00E11C92C3E60075F4F7 /* MTLRuntimeRoutines.h */; };
+		256D00E51C92C3EE0075F4F7 /* MTLRuntimeTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 256D00DF1C92C3E60075F4F7 /* MTLRuntimeTests.m */; };
+		256D00E61C92C3EF0075F4F7 /* MTLRuntimeTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 256D00DF1C92C3E60075F4F7 /* MTLRuntimeTests.m */; };
+		256D00E71C92C3F20075F4F7 /* MTLRuntimeRoutines.m in Sources */ = {isa = PBXBuildFile; fileRef = 256D00E01C92C3E60075F4F7 /* MTLRuntimeRoutines.m */; };
+		256D00E81C92C3F20075F4F7 /* MTLRuntimeRoutines.m in Sources */ = {isa = PBXBuildFile; fileRef = 256D00E01C92C3E60075F4F7 /* MTLRuntimeRoutines.m */; };
 		547AE0FD17882ED100F4437D /* MTLModelValidationSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 547AE0FC17882ED100F4437D /* MTLModelValidationSpec.m */; };
 		54803A34178829A800011B39 /* NSError+MTLModelException.m in Sources */ = {isa = PBXBuildFile; fileRef = 54803A31178829A700011B39 /* NSError+MTLModelException.m */; };
 		54803A3B17882CCD00011B39 /* MTLErrorModelExceptionSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 54803A3A17882CCD00011B39 /* MTLErrorModelExceptionSpec.m */; };
@@ -160,6 +165,9 @@
 		1ED5B5CB163A4E2B0072668E /* MTLComparisonAdditionsSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MTLComparisonAdditionsSpec.m; sourceTree = "<group>"; };
 		1ED5B5CE163A4E3C0072668E /* NSObject+MTLComparisonAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSObject+MTLComparisonAdditions.h"; sourceTree = "<group>"; };
 		1ED5B5CF163A4E3C0072668E /* NSObject+MTLComparisonAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSObject+MTLComparisonAdditions.m"; sourceTree = "<group>"; };
+		256D00DF1C92C3E60075F4F7 /* MTLRuntimeTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = MTLRuntimeTests.m; path = RuntimeTests/MTLRuntimeTests.m; sourceTree = "<group>"; };
+		256D00E01C92C3E60075F4F7 /* MTLRuntimeRoutines.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = MTLRuntimeRoutines.m; path = RuntimeTests/MTLRuntimeRoutines.m; sourceTree = "<group>"; };
+		256D00E11C92C3E60075F4F7 /* MTLRuntimeRoutines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MTLRuntimeRoutines.h; path = RuntimeTests/MTLRuntimeRoutines.h; sourceTree = "<group>"; };
 		541B02B31805EC4C000DA87C /* MTLTransformerErrorExamples.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MTLTransformerErrorExamples.h; sourceTree = "<group>"; };
 		541B02B41805EC4C000DA87C /* MTLTransformerErrorExamples.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MTLTransformerErrorExamples.m; sourceTree = "<group>"; };
 		547165A31801977000E734DB /* MTLTransformerErrorHandling.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MTLTransformerErrorHandling.h; sourceTree = "<group>"; };
@@ -289,6 +297,16 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		256D00D31C92C18B0075F4F7 /* Runtime Tests */ = {
+			isa = PBXGroup;
+			children = (
+				256D00DF1C92C3E60075F4F7 /* MTLRuntimeTests.m */,
+				256D00E11C92C3E60075F4F7 /* MTLRuntimeRoutines.h */,
+				256D00E01C92C3E60075F4F7 /* MTLRuntimeRoutines.m */,
+			);
+			name = "Runtime Tests";
+			sourceTree = "<group>";
+		};
 		D01BD0AB16CB46B600EC95C7 /* Adapters */ = {
 			isa = PBXGroup;
 			children = (
@@ -354,6 +372,7 @@
 				D042FC4C15F72B23004E8054 /* Mantle.h */,
 				D0760E7015FFBF020060F550 /* Modules */,
 				D090E62515F730B2005282F9 /* Extensions */,
+				256D00D31C92C18B0075F4F7 /* Runtime Tests */,
 				D042FC4615F72B23004E8054 /* Supporting Files */,
 			);
 			path = Mantle;
@@ -560,6 +579,7 @@
 				D01BD09D16CB432D00EC95C7 /* MTLJSONAdapter.h in Headers */,
 				D05317721A168D3D00A5FBE2 /* MTLTransformerErrorHandling.h in Headers */,
 				D01BD0AF16CB52E800EC95C7 /* MTLModel+NSCoding.h in Headers */,
+				256D00E41C92C3E60075F4F7 /* MTLRuntimeRoutines.h in Headers */,
 				A18397E81BA341DC00AB37BA /* metamacros.h in Headers */,
 				D0BFC36F17476B4700F5DC5D /* NSValueTransformer+MTLInversionAdditions.h in Headers */,
 			);
@@ -768,12 +788,14 @@
 				D0760EC915FFCA4E0060F550 /* MTLTestModel.m in Sources */,
 				54803A3B17882CCD00011B39 /* MTLErrorModelExceptionSpec.m in Sources */,
 				D05317711A168D3500A5FBE2 /* MTLTransformerErrorExamples.m in Sources */,
+				256D00E51C92C3EE0075F4F7 /* MTLRuntimeTests.m in Sources */,
 				D0E9C3A919F6E5AA000D427D /* SwiftSpec.swift in Sources */,
 				D08B5AB216002A23001FE685 /* MTLValueTransformerSpec.m in Sources */,
 				88080C1D160A719D00CCABF2 /* MTLArrayManipulationSpec.m in Sources */,
 				D053177E1A168F8B00A5FBE2 /* MTLTestJSONAdapter.m in Sources */,
 				D0C27CF6161107E5002FE587 /* MTLDictionaryManipulationSpec.m in Sources */,
 				547AE0FD17882ED100F4437D /* MTLModelValidationSpec.m in Sources */,
+				256D00E71C92C3F20075F4F7 /* MTLRuntimeRoutines.m in Sources */,
 				D0F1174D1614C8000092520B /* MTLPredefinedTransformerAdditionsSpec.m in Sources */,
 				1ED5B5CC163A4E2B0072668E /* MTLComparisonAdditionsSpec.m in Sources */,
 				D02E48EA16CB8ACA00257645 /* MTLModelNSCodingSpec.m in Sources */,
@@ -824,6 +846,8 @@
 				D053177F1A168F8B00A5FBE2 /* MTLTestJSONAdapter.m in Sources */,
 				D0E9C39E19F6E04B000D427D /* MTLDictionaryManipulationSpec.m in Sources */,
 				D0E9C39D19F6E04B000D427D /* MTLComparisonAdditionsSpec.m in Sources */,
+				256D00E61C92C3EF0075F4F7 /* MTLRuntimeTests.m in Sources */,
+				256D00E81C92C3F20075F4F7 /* MTLRuntimeRoutines.m in Sources */,
 				D0E9C3AF19F6E74C000D427D /* (null) in Sources */,
 				D05317701A168D3400A5FBE2 /* MTLTransformerErrorExamples.m in Sources */,
 				D0E9C3AA19F6E5AA000D427D /* SwiftSpec.swift in Sources */,

--- a/Mantle/RuntimeTests/MTLRuntimeRoutines.h
+++ b/Mantle/RuntimeTests/MTLRuntimeRoutines.h
@@ -1,0 +1,12 @@
+//
+//  MTLRuntimeRoutines.h
+//  Mantle
+//
+//  Created by Anton Bukov on 3/11/16.
+//  Copyright (c) 2016 ML-Works. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+void MTLRuntimeEnumerateClasses(void (^block)(Class class));
+void MTLRuntimeEnumerateClassSubclasses(Class parentclass, void (^block)(Class class));

--- a/Mantle/RuntimeTests/MTLRuntimeRoutines.m
+++ b/Mantle/RuntimeTests/MTLRuntimeRoutines.m
@@ -1,0 +1,37 @@
+//
+//  MTLRuntimeRoutines.m
+//  Mantle
+//
+//  Created by Anton Bukov on 3/11/16.
+//  Copyright (c) 2016 ML-Works. All rights reserved.
+//
+
+#import <objc/runtime.h>
+#import "MTLRuntimeRoutines.h"
+
+void MTLRuntimeEnumerateClasses(void (^block)(Class class)) {
+	MTLRuntimeEnumerateClassSubclasses([NSObject class], block);
+}
+
+void MTLRuntimeEnumerateClassSubclasses(Class parentclass, void (^block)(Class class)) {
+	int classesCount = objc_getClassList(NULL, 0);
+	Class *classes = (Class *)malloc(classesCount * sizeof(Class));
+	objc_getClassList(classes, classesCount);
+	
+	for (int i = 0; i < classesCount; i++) {
+		Class class = classes[i];
+		
+		// Filter only NSObject subclasses
+		Class superclass = class;
+		while (superclass && superclass != parentclass) {
+			superclass = class_getSuperclass(superclass);
+		}
+		if (!superclass) {
+			continue;
+		}
+		
+		block(class);
+	}
+	
+	free(classes);
+}

--- a/Mantle/RuntimeTests/MTLRuntimeTests.m
+++ b/Mantle/RuntimeTests/MTLRuntimeTests.m
@@ -1,0 +1,132 @@
+//
+//  MTLRuntimeTests.m
+//  Mantle
+//
+//  Created by Anton Bukov on 3/11/16.
+//  Copyright (c) 2016 ML-Works. All rights reserved.
+//
+
+#if __has_include(<Mantle/Mantle.h>)
+
+#import <XCTest/XCTest.h>
+#import <Mantle/Mantle.h>
+#import "MTLRuntimeRoutines.h"
+
+#pragma mark - Fail example for testJSONKeyPathsByPropertyKey
+
+@interface MTLRuntimeClass_testJSONKeyPathsByPropertyKey : MTLModel <MTLJSONSerializing>
+@end
+@implementation MTLRuntimeClass_testJSONKeyPathsByPropertyKey
++ (NSDictionary *)JSONKeyPathsByPropertyKey {
+	return @{ @"a": @"hello" };
+}
+@end
+
+@interface MTLRuntimeSubclass_testJSONKeyPathsByPropertyKey : MTLRuntimeClass_testJSONKeyPathsByPropertyKey
+@end
+@implementation MTLRuntimeSubclass_testJSONKeyPathsByPropertyKey
++ (NSDictionary *)JSONKeyPathsByPropertyKey {
+	return @{ @"b": @"world" };
+}
+@end
+
+#pragma mark - Fail example for testJSONTransformerForKey
+
+@interface MTLRuntimeClass_testJSONTransformerForKey : MTLModel <MTLJSONSerializing>
+@end
+@implementation MTLRuntimeClass_testJSONTransformerForKey
++ (NSDictionary *)JSONKeyPathsByPropertyKey {
+	return @{ @"a": @"hello" };
+}
++ (NSValueTransformer *)JSONTransformerForKey:(NSString *)key {
+	return @{
+		@"a": [NSValueTransformer valueTransformerForName:MTLURLValueTransformerName],
+	}[key];
+}
+@end
+
+@interface MTLRuntimeSubclass_testJSONTransformerForKey : MTLRuntimeClass_testJSONTransformerForKey
+@end
+@implementation MTLRuntimeSubclass_testJSONTransformerForKey
++ (NSDictionary *)JSONKeyPathsByPropertyKey {
+	return [super.JSONKeyPathsByPropertyKey mtl_dictionaryByAddingEntriesFromDictionary:@{ @"b": @"world" }];
+}
++ (NSValueTransformer *)JSONTransformerForKey:(NSString *)key {
+	return @{
+		@"b": [NSValueTransformer valueTransformerForName:MTLURLValueTransformerName],
+	}[key];
+}
+@end
+
+#pragma mark - Tests
+
+@interface MTLRuntimeTests : XCTestCase
+
+@end
+
+@implementation MTLRuntimeTests
+
+- (void)testJSONKeyPathsByPropertyKey
+{
+	__block BOOL foundMTLRuntimeSubclass = NO;
+	
+	MTLRuntimeEnumerateClasses(^(Class class){
+		if ([class respondsToSelector:@selector(JSONKeyPathsByPropertyKey)] &&
+			[class.superclass respondsToSelector:@selector(JSONKeyPathsByPropertyKey)]) {
+			
+			NSSet *keys = [NSSet setWithArray:[class JSONKeyPathsByPropertyKey].allKeys];
+			NSSet *superkeys = [NSSet setWithArray:[class.superclass JSONKeyPathsByPropertyKey].allKeys];
+			
+			if (![superkeys isSubsetOfSet:keys]) {
+				if (class == [MTLRuntimeSubclass_testJSONKeyPathsByPropertyKey class]) {
+					foundMTLRuntimeSubclass = YES;
+				}
+				else {
+					XCTFail(@"Class %@ should call supers method JSONKeyPathsByPropertyKey like this: [super.JSONKeyPathsByPropertyKey mtl_dictionaryByAddingEntriesFromDictionary:@{...}];", class);
+				}
+			}
+		}
+	});
+	
+	XCTAssertTrue(foundMTLRuntimeSubclass, @"Test is broken!");
+}
+
+- (void)testJSONTransformerForKey
+{
+	__block BOOL foundMTLRuntimeSubclass = NO;
+	
+	MTLRuntimeEnumerateClasses(^(Class class){
+		if ([class respondsToSelector:@selector(JSONTransformerForKey:)] &&
+			[class.superclass respondsToSelector:@selector(JSONTransformerForKey:)]) {
+			
+			NSMutableSet *keys = [NSMutableSet set];
+			for (NSString *key in [class JSONKeyPathsByPropertyKey].allKeys) {
+				if ([class JSONTransformerForKey:key]) {
+					[keys addObject:key];
+				}
+			}
+			
+			NSMutableSet *superkeys = [NSMutableSet set];
+			for (NSString *key in [class.superclass JSONKeyPathsByPropertyKey].allKeys) {
+				if ([class.superclass JSONTransformerForKey:key]) {
+					[superkeys addObject:key];
+				}
+			}
+			
+			if (![superkeys isSubsetOfSet:keys]) {
+				if (class == [MTLRuntimeSubclass_testJSONTransformerForKey class]) {
+					foundMTLRuntimeSubclass = YES;
+				}
+				else {
+					XCTFail(@"Class %@ should call supers method JSONTransformerForKey like this: return [super JSONTransformerForKey:key] ?: @{...}[key];", class);
+				}
+			}
+		}
+	});
+	
+	XCTAssertTrue(foundMTLRuntimeSubclass, @"Test is broken!");
+}
+
+@end
+
+#endif


### PR DESCRIPTION
Added runtime test that should be used like this in user apps:

``` objective-c
target 'MyApp' do
pod 'Mantle'
end

target 'MyAppTests' do
pod 'Mantle/RuntimeTests'
end
```

Here is `podspec` fragment example:

``` json
...
"subspecs": [
  {
    "name": "RuntimeTests",
    "source_files": "Mantle/RuntimeTests",
    "private_header_files": "Mantle/RuntimeTests/*.h",
    "dependency": "Mantle"
  }
]
...
```

There are a 2 tests:
1) Testing you not forgot to call and append supers `JSONKeyPathsByPropertyKey` method result
2) Testing you not forgot to call supers `JSONTransformerForKey` method

This methods if declared in subclasses should extend parents methods results, otherwise runtime tests will fail. This tests will check all classes in your app, no matter wanna you to test them or not :)
