### PR TITLE
logic mistake

### DIFF
--- a/Mantle/MTLJSONAdapter.m
+++ b/Mantle/MTLJSONAdapter.m
@@ -383,9 +383,10 @@ NSString * const MTLJSONAdapterThrownExceptionErrorKey = @"MTLJSONAdapterThrownE
 		if ([modelClass respondsToSelector:@selector(JSONTransformerForKey:)]) {
 			NSValueTransformer *transformer = [modelClass JSONTransformerForKey:key];
 
-			if (transformer != nil) result[key] = transformer;
-
-			continue;
+      if (transformer != nil) {
+          result[key] = transformer;    
+          continue;
+      }
 		}
 
 		objc_property_t property = class_getProperty(modelClass, key.UTF8String);


### PR DESCRIPTION
```
@interface Restaurant : MTLModel
@property NSString *ID;
@property NSNumer *level;
@property UIColor *color;
@end
@implementation Restaurant
+ (NSDictionary *)JSONKeyPathsByPropertyKey {
  return @{
          @"ID":@"id",
          @"color":@"hex",
          @"level":@"level"};
}

+ (NSValueTransformer *)JSONTransformerForKey:(NSString *)key {
  if ([key isEqualToString:NSStringFromSelector(@selector(color))]) {
    return [NSValueTransformer valueTransformerForName:HexToColorTransformerName];
  }
  return nil;
}
@end
```

1. If `JSONTransformerForKey:` is used in Model, but only the  "color" key will return a transform, other keys will return nil by default.
2. I have a "ToStringTransform" which converts value to NSString instead of NSNumer. Any I register it in `NSValueTransformer` category in `+(void)load`

In `MTLJSONAdapter.m` line 386, a logic mistake will happen if continue is not together with `result[key] = transformer` in the same scope. ToStringTransform will not work?