### PR TITLE
Add extra context to JSONTransformerForKey method

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,6 +382,8 @@ deserializing from JSON.
 }
 ```
 
+`key` is the key that applies to your model object; not the original JSON key. Keep this in mind if you transform the key names using `+JSONKeyPathsByPropertyKey`.
+
 For added convenience, if you implement `+<key>JSONTransformer`,
 `MTLJSONAdapter` will use the result of that method instead. For example, dates
 that are commonly represented as strings in JSON can be transformed to `NSDate`s


### PR DESCRIPTION
The README is ambiguous about what the value of `key` should be when implementing `JSONTransformerForKey:`. This PR addresses that by adding additional context.