### PR TITLE
Fix url transforming

### DIFF
--- a/Mantle/NSValueTransformer+MTLPredefinedTransformerAdditions.m
+++ b/Mantle/NSValueTransformer+MTLPredefinedTransformerAdditions.m
@@ -38,8 +38,10 @@ NSString * const MTLBooleanValueTransformerName = @"MTLBooleanValueTransformerNa
 					return nil;
 				}
 
-				NSURL *result = [NSURL URLWithString:str];
-
+				NSString *urlString = [str stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]];
+				NSURLComponents *urlComponents = [NSURLComponents componentsWithString:urlString];
+				NSURL *result = (urlComponents.host) ? urlComponents.URL : nil;
+				
 				if (result == nil) {
 					if (error != NULL) {
 						NSDictionary *userInfo = @{

--- a/MantleTests/MTLPredefinedTransformerAdditionsSpec.m
+++ b/MantleTests/MTLPredefinedTransformerAdditionsSpec.m
@@ -40,6 +40,11 @@ describe(@"The URL transformer", ^{
 		expect([transformer transformedValue:nil]).to(beNil());
 		expect([transformer reverseTransformedValue:nil]).to(beNil());
 	});
+	
+	it(@"should convert NSString with forbidden url symbols to NSURL", ^{
+		NSString *urlString = @"https://en.wikipedia.org/wiki/Arsène_Wenger";
+		expect([transformer transformedValue:urlString]).notTo(beNil());
+	});
 
 	itBehavesLike(MTLTransformerErrorExamples, ^{
 		return @{


### PR DESCRIPTION
Url transforming breaks if you try to transform url with forbidden symbols. For example: https://en.wikipedia.org/wiki/Arsène_Wenger