### PR TITLE
fix a race condition in +[MTLJSONAdapter dictionaryTransformerWithModelClass]

### DIFF
--- a/Mantle/MTLJSONAdapter.m
+++ b/Mantle/MTLJSONAdapter.m
@@ -498,7 +498,11 @@ NSString * const MTLJSONAdapterThrownExceptionErrorKey = @"MTLJSONAdapterThrownE
 			}
 
 			if (!adapter) {
-				adapter = [[self alloc] initWithModelClass:modelClass];
+				@synchronized (self) {
+					if (!adapter) {
+						adapter = [[self alloc] initWithModelClass:modelClass];
+					}
+				}
 			}
 			id model = [adapter modelFromJSONDictionary:JSONDictionary error:error];
 			if (model == nil) {
@@ -525,7 +529,11 @@ NSString * const MTLJSONAdapterThrownExceptionErrorKey = @"MTLJSONAdapterThrownE
 			}
 
 			if (!adapter) {
-				adapter = [[self alloc] initWithModelClass:modelClass];
+				@synchronized (self) {
+					if (!adapter) {
+						adapter = [[self alloc] initWithModelClass:modelClass];
+					}
+				}
 			}
 			NSDictionary *result = [adapter JSONDictionaryFromModel:model error:error];
 			if (result == nil) {


### PR DESCRIPTION
This fixes #615 
#### Problem

``` Objective-C
__block MTLJSONAdapter *adapter;

return [MTLValueTransformer
        transformerUsingForwardBlock:^ id (id JSONDictionary, BOOL *success, NSError **error) {
            //...
            if (!adapter) {
                adapter = [[self alloc] initWithModelClass:modelClass];
            }
            //...
        }
        reverseBlock:^ NSDictionary * (id model, BOOL *success, NSError **error) {
            //...
        }];
```

The `adapter` is captured by the "forward" and "reverse" transform block, and is then created lazily.

If the transformer this method returns is accessed and used in multiple threads, the "forward" or "reverse"  block may be entered at the same time by different threads.

This creates a race condition:

Assume thread A and B enter a transformer's "forward" block at the same time.

Thread A may create an adapter and assign it to the pointer `adapter` while thread B is using an adapter it just created. This causes the adapter created by B to be dealloc-ed, since there's no other "strong" reference to the adapter (we only have one `adapter` pointer/reference for one transformer). So any subsequent access to that adapter will cause a crash.
#### Fix

This PR adds a `@synchronized` block around the adapter creation code:

``` Objective-C
if (!adapter) {
    @synchronized (self) {
        if (!adapter) {
            adapter = [[self alloc] initWithModelClass:modelClass];
        }
    }
}
```
#### Considerations
- We should either make the transformer thread-safe, or point it out in the documentation.
- This PR uses the `MTLJSONAdapter` class as the lock token. But, in fact, we should use the transformer instance as the lock token (we are preventing a race condition in blocks of a transformer instance), however it is not possible because the transformer instance is not created yet when the "forward" and "reverse" block are created.
  
  Should we create a new object as the lock token; use a different kind of lock, or simply use the `MTLJSONAdapter` class as the lock token?
