### PR TITLE
(MTLModel) workaround for memory leat - remove init() and use super.init() instead - issue #721

### DIFF
--- a/Mantle/MTLModel.h
+++ b/Mantle/MTLModel.h
@@ -115,11 +115,6 @@ typedef enum : NSUInteger {
 /// Returns an initialized model object, or nil if validation failed.
 - (instancetype)initWithDictionary:(NSDictionary *)dictionaryValue error:(NSError **)error;
 
-/// Initializes the receiver with default values.
-///
-/// This is the designated initializer for this class.
-- (instancetype)init;
-
 /// By default, this method looks for a `-merge<Key>FromModel:` method on the
 /// receiver, and invokes it if found. If not found, and `model` is not nil, the
 /// value for the given key is taken from `model`.

--- a/Mantle/MTLModel.m
+++ b/Mantle/MTLModel.m
@@ -124,13 +124,8 @@ static BOOL MTLValidateAndSetValue(id obj, NSString *key, id value, BOOL forceUp
 	return [[self alloc] initWithDictionary:dictionary error:error];
 }
 
-- (instancetype)init {
-	// Nothing special by default, but we have a declaration in the header.
-	return [super init];
-}
-
 - (instancetype)initWithDictionary:(NSDictionary *)dictionary error:(NSError **)error {
-	self = [self init];
+	self = [super init];
 	if (self == nil) return nil;
 
 	for (NSString *key in dictionary) {


### PR DESCRIPTION
(MTLModel) workaround for memory leat - remove init() and use super.init() instead
https://github.com/Mantle/Mantle/issues/721
