### PR TITLE
Failing/Crashing test + fix

### DIFF
--- a/Mantle/MTLJSONAdapter.m
+++ b/Mantle/MTLJSONAdapter.m
@@ -281,6 +281,17 @@ NSString * const MTLJSONAdapterThrownExceptionErrorKey = @"MTLJSONAdapterThrownE
 		}
 	}
 
+	if (JSONDictionary == nil || ![JSONDictionary isKindOfClass:NSDictionary.class]) {
+		if (error != NULL) {
+			NSDictionary *userInfo = @{
+									   NSLocalizedDescriptionKey: NSLocalizedString(@"Missing JSON dictionary", @""),
+									   NSLocalizedFailureReasonErrorKey: [NSString stringWithFormat:NSLocalizedString(@"%@ could not be created because an invalid JSON dictionary was provided: %@", @""), NSStringFromClass(self.modelClass), JSONDictionary.class],
+									   };
+			*error = [NSError errorWithDomain:MTLJSONAdapterErrorDomain code:MTLJSONAdapterErrorInvalidJSONDictionary userInfo:userInfo];
+		}
+		return nil;
+	}
+
 	NSMutableDictionary *dictionaryValue = [[NSMutableDictionary alloc] initWithCapacity:JSONDictionary.count];
 
 	for (NSString *propertyKey in [self.modelClass propertyKeys]) {

--- a/Mantle/MTLJSONAdapter.m
+++ b/Mantle/MTLJSONAdapter.m
@@ -284,9 +284,9 @@ NSString * const MTLJSONAdapterThrownExceptionErrorKey = @"MTLJSONAdapterThrownE
 	if (JSONDictionary == nil || ![JSONDictionary isKindOfClass:NSDictionary.class]) {
 		if (error != NULL) {
 			NSDictionary *userInfo = @{
-									   NSLocalizedDescriptionKey: NSLocalizedString(@"Missing JSON dictionary", @""),
-									   NSLocalizedFailureReasonErrorKey: [NSString stringWithFormat:NSLocalizedString(@"%@ could not be created because an invalid JSON dictionary was provided: %@", @""), NSStringFromClass(self.modelClass), JSONDictionary.class],
-									   };
+				NSLocalizedDescriptionKey: NSLocalizedString(@"Missing JSON dictionary", @""),
+				NSLocalizedFailureReasonErrorKey: [NSString stringWithFormat:NSLocalizedString(@"%@ could not be created because an invalid JSON dictionary was provided: %@", @""), NSStringFromClass(self.modelClass), JSONDictionary.class],
+			};
 			*error = [NSError errorWithDomain:MTLJSONAdapterErrorDomain code:MTLJSONAdapterErrorInvalidJSONDictionary userInfo:userInfo];
 		}
 		return nil;

--- a/MantleTests/MTLJSONAdapterSpec.m
+++ b/MantleTests/MTLJSONAdapterSpec.m
@@ -574,6 +574,14 @@ describe(@"Deserializing multiple models", ^{
 
 		expect(models).to(equal(expected));
 	});
+	
+	it(@"should return empty array on wrong input data", ^{
+		NSError *error = nil;
+		NSArray *models = [MTLJSONAdapter modelsOfClass:MTLTestModel.class fromJSONArray:@[@"foo", @"bar"] error:&error];
+
+		expect(@(models.count)).to(equal(@0));
+		expect(error).notTo(beNil());
+	});
 });
 
 it(@"should return nil and an error if it fails to initialize any model from an array", ^{


### PR DESCRIPTION
This test fails on 2.x but passes on 1.x

1.5.8 has following error set:

```
(lldb) po error
Error Domain=MTLJSONAdapterErrorDomain Code=3 "Missing JSON dictionary" UserInfo={NSLocalizedDescription=Missing JSON dictionary, NSLocalizedFailureReason=MTLTestModel could not be created because an invalid JSON dictionary was provided: __NSCFConstantString}
```

The doc clearly states that we have to provide an array of JSON Dictionary but I think the old behaviour of returning an empty array + setting an error was better than crashing.

Comments?

(Crash occurs because method `count` gets called on every element in the array, which crashes on the here provided String
File: MTLJSONAdapter.m
Line: 284
)
