### PR TITLE
Explicit add __autoreleasing to NSError** declaration

### DIFF
--- a/Mantle/MTLJSONAdapter.h
+++ b/Mantle/MTLJSONAdapter.h
@@ -112,7 +112,7 @@ extern NSString * const MTLJSONAdapterThrownExceptionErrorKey;
 ///
 /// Returns an instance of `modelClass` upon success, or nil if a parsing error
 /// occurred.
-+ (id)modelOfClass:(Class)modelClass fromJSONDictionary:(NSDictionary *)JSONDictionary error:(NSError **)error;
++ (id)modelOfClass:(Class)modelClass fromJSONDictionary:(NSDictionary *)JSONDictionary error:(NSError * __autoreleasing *)error;
 
 /// Attempts to parse an array of JSON dictionary objects into a model objects
 /// of a specific class.
@@ -129,7 +129,7 @@ extern NSString * const MTLJSONAdapterThrownExceptionErrorKey;
 ///
 /// Returns an array of `modelClass` instances upon success, or nil if a parsing
 /// error occurred.
-+ (NSArray *)modelsOfClass:(Class)modelClass fromJSONArray:(NSArray *)JSONArray error:(NSError **)error;
++ (NSArray *)modelsOfClass:(Class)modelClass fromJSONArray:(NSArray *)JSONArray error:(NSError * __autoreleasing *)error;
 
 /// Converts a model into a JSON representation.
 ///
@@ -139,7 +139,7 @@ extern NSString * const MTLJSONAdapterThrownExceptionErrorKey;
 ///         serializing.
 ///
 /// Returns a JSON dictionary, or nil if a serialization error occurred.
-+ (NSDictionary *)JSONDictionaryFromModel:(id<MTLJSONSerializing>)model error:(NSError **)error;
++ (NSDictionary *)JSONDictionaryFromModel:(id<MTLJSONSerializing>)model error:(NSError * __autoreleasing *)error;
 
 /// Converts a array of models into a JSON representation.
 ///
@@ -150,7 +150,7 @@ extern NSString * const MTLJSONAdapterThrownExceptionErrorKey;
 ///
 /// Returns a JSON array, or nil if a serialization error occurred for any
 /// model.
-+ (NSArray *)JSONArrayFromModels:(NSArray *)models error:(NSError **)error;
++ (NSArray *)JSONArrayFromModels:(NSArray *)models error:(NSError * __autoreleasing *)error;
 
 /// Initializes the receiver with a given model class.
 ///
@@ -174,7 +174,7 @@ extern NSString * const MTLJSONAdapterThrownExceptionErrorKey;
 ///
 /// Returns a model object, or nil if a deserialization error occurred or the
 /// model did not validate successfully.
-- (id)modelFromJSONDictionary:(NSDictionary *)JSONDictionary error:(NSError **)error;
+- (id)modelFromJSONDictionary:(NSDictionary *)JSONDictionary error:(NSError * __autoreleasing *)error;
 
 /// Serializes a model into JSON.
 ///
@@ -184,7 +184,7 @@ extern NSString * const MTLJSONAdapterThrownExceptionErrorKey;
 ///         serializing.
 ///
 /// Returns a model object, or nil if a serialization error occurred.
-- (NSDictionary *)JSONDictionaryFromModel:(id<MTLJSONSerializing>)model error:(NSError **)error;
+- (NSDictionary *)JSONDictionaryFromModel:(id<MTLJSONSerializing>)model error:(NSError * __autoreleasing *)error;
 
 /// Filters the property keys used to serialize a given model.
 ///
@@ -280,8 +280,8 @@ extern NSString * const MTLJSONAdapterThrownExceptionErrorKey;
 
 - (NSDictionary *)JSONDictionary __attribute__((unavailable("Replaced by -JSONDictionaryFromModel:error:"))) NS_SWIFT_UNAVAILABLE("Replaced by -JSONDictionaryFromModel:error:");
 - (NSString *)JSONKeyPathForPropertyKey:(NSString *)key __attribute__((unavailable("Replaced by -serializablePropertyKeys:forModel:")));
-- (id)initWithJSONDictionary:(NSDictionary *)JSONDictionary modelClass:(Class)modelClass error:(NSError **)error __attribute__((unavailable("Replaced by -initWithModelClass:")));
+- (id)initWithJSONDictionary:(NSDictionary *)JSONDictionary modelClass:(Class)modelClass error:(NSError * __autoreleasing *)error __attribute__((unavailable("Replaced by -initWithModelClass:")));
 - (id)initWithModel:(id<MTLJSONSerializing>)model __attribute__((unavailable("Replaced by -initWithModelClass:"))) NS_SWIFT_UNAVAILABLE("Replaced by -initWithModelClass:");
-- (NSDictionary *)serializeToJSONDictionary:(NSError **)error __attribute__((unavailable("Replaced by -JSONDictionaryFromModel:error:"))) NS_SWIFT_UNAVAILABLE("Replaced by -JSONDictionaryFromModel:error:");
+- (NSDictionary *)serializeToJSONDictionary:(NSError * __autoreleasing *)error __attribute__((unavailable("Replaced by -JSONDictionaryFromModel:error:"))) NS_SWIFT_UNAVAILABLE("Replaced by -JSONDictionaryFromModel:error:");
 
 @end

--- a/Mantle/MTLJSONAdapter.m
+++ b/Mantle/MTLJSONAdapter.m
@@ -480,7 +480,7 @@ NSString * const MTLJSONAdapterThrownExceptionErrorKey = @"MTLJSONAdapterThrownE
 	__block MTLJSONAdapter *adapter;
 	
 	return [MTLValueTransformer
-		transformerUsingForwardBlock:^ id (id JSONDictionary, BOOL *success, NSError **error) {
+		transformerUsingForwardBlock:^ id (id JSONDictionary, BOOL *success, NSError * __autoreleasing *error) {
 			if (JSONDictionary == nil) return nil;
 			
 			if (![JSONDictionary isKindOfClass:NSDictionary.class]) {
@@ -507,7 +507,7 @@ NSString * const MTLJSONAdapterThrownExceptionErrorKey = @"MTLJSONAdapterThrownE
 
 			return model;
 		}
-		reverseBlock:^ NSDictionary * (id model, BOOL *success, NSError **error) {
+		reverseBlock:^ NSDictionary * (id model, BOOL *success, NSError * __autoreleasing *error) {
 			if (model == nil) return nil;
 			
 			if (![model conformsToProtocol:@protocol(MTLModel)] || ![model conformsToProtocol:@protocol(MTLJSONSerializing)]) {
@@ -540,7 +540,7 @@ NSString * const MTLJSONAdapterThrownExceptionErrorKey = @"MTLJSONAdapterThrownE
 	id<MTLTransformerErrorHandling> dictionaryTransformer = [self dictionaryTransformerWithModelClass:modelClass];
 	
 	return [MTLValueTransformer
-		transformerUsingForwardBlock:^ id (NSArray *dictionaries, BOOL *success, NSError **error) {
+		transformerUsingForwardBlock:^ id (NSArray *dictionaries, BOOL *success, NSError * __autoreleasing *error) {
 			if (dictionaries == nil) return nil;
 			
 			if (![dictionaries isKindOfClass:NSArray.class]) {
@@ -589,7 +589,7 @@ NSString * const MTLJSONAdapterThrownExceptionErrorKey = @"MTLJSONAdapterThrownE
 			
 			return models;
 		}
-		reverseBlock:^ id (NSArray *models, BOOL *success, NSError **error) {
+		reverseBlock:^ id (NSArray *models, BOOL *success, NSError * __autoreleasing *error) {
 			if (models == nil) return nil;
 			
 			if (![models isKindOfClass:NSArray.class]) {

--- a/Mantle/MTLJSONAdapter.m
+++ b/Mantle/MTLJSONAdapter.m
@@ -56,7 +56,7 @@ NSString * const MTLJSONAdapterThrownExceptionErrorKey = @"MTLJSONAdapterThrownE
 //
 // Returns a JSON adapter for modelClass, creating one of necessary. If no
 // adapter could be created, nil is returned.
-- (MTLJSONAdapter *)JSONAdapterForModelClass:(Class)modelClass error:(NSError **)error;
+- (MTLJSONAdapter *)JSONAdapterForModelClass:(Class)modelClass error:(NSError * __autoreleasing *)error;
 
 // Collect all value transformers needed for a given class.
 //
@@ -73,13 +73,13 @@ NSString * const MTLJSONAdapterThrownExceptionErrorKey = @"MTLJSONAdapterThrownE
 
 #pragma mark Convenience methods
 
-+ (id)modelOfClass:(Class)modelClass fromJSONDictionary:(NSDictionary *)JSONDictionary error:(NSError **)error {
++ (id)modelOfClass:(Class)modelClass fromJSONDictionary:(NSDictionary *)JSONDictionary error:(NSError * __autoreleasing *)error {
 	MTLJSONAdapter *adapter = [[self alloc] initWithModelClass:modelClass];
 
 	return [adapter modelFromJSONDictionary:JSONDictionary error:error];
 }
 
-+ (NSArray *)modelsOfClass:(Class)modelClass fromJSONArray:(NSArray *)JSONArray error:(NSError **)error {
++ (NSArray *)modelsOfClass:(Class)modelClass fromJSONArray:(NSArray *)JSONArray error:(NSError * __autoreleasing *)error {
 	if (JSONArray == nil || ![JSONArray isKindOfClass:NSArray.class]) {
 		if (error != NULL) {
 			NSDictionary *userInfo = @{
@@ -103,13 +103,13 @@ NSString * const MTLJSONAdapterThrownExceptionErrorKey = @"MTLJSONAdapterThrownE
 	return models;
 }
 
-+ (NSDictionary *)JSONDictionaryFromModel:(id<MTLJSONSerializing>)model error:(NSError **)error {
++ (NSDictionary *)JSONDictionaryFromModel:(id<MTLJSONSerializing>)model error:(NSError * __autoreleasing *)error {
 	MTLJSONAdapter *adapter = [[self alloc] initWithModelClass:model.class];
 
 	return [adapter JSONDictionaryFromModel:model error:error];
 }
 
-+ (NSArray *)JSONArrayFromModels:(NSArray *)models error:(NSError **)error {
++ (NSArray *)JSONArrayFromModels:(NSArray *)models error:(NSError * __autoreleasing *)error {
 	NSParameterAssert(models != nil);
 	NSParameterAssert([models isKindOfClass:NSArray.class]);
 
@@ -174,7 +174,7 @@ NSString * const MTLJSONAdapterThrownExceptionErrorKey = @"MTLJSONAdapterThrownE
 
 #pragma mark Serialization
 
-- (NSDictionary *)JSONDictionaryFromModel:(id<MTLJSONSerializing>)model error:(NSError **)error {
+- (NSDictionary *)JSONDictionaryFromModel:(id<MTLJSONSerializing>)model error:(NSError * __autoreleasing *)error {
 	NSParameterAssert(model != nil);
 	NSParameterAssert([model isKindOfClass:self.modelClass]);
 
@@ -256,7 +256,7 @@ NSString * const MTLJSONAdapterThrownExceptionErrorKey = @"MTLJSONAdapterThrownE
 	}
 }
 
-- (id)modelFromJSONDictionary:(NSDictionary *)JSONDictionary error:(NSError **)error {
+- (id)modelFromJSONDictionary:(NSDictionary *)JSONDictionary error:(NSError * __autoreleasing *)error {
 	if ([self.modelClass respondsToSelector:@selector(classForParsingJSONDictionary:)]) {
 		Class class = [self.modelClass classForParsingJSONDictionary:JSONDictionary];
 		if (class == nil) {
@@ -424,7 +424,7 @@ NSString * const MTLJSONAdapterThrownExceptionErrorKey = @"MTLJSONAdapterThrownE
 	return result;
 }
 
-- (MTLJSONAdapter *)JSONAdapterForModelClass:(Class)modelClass error:(NSError **)error {
+- (MTLJSONAdapter *)JSONAdapterForModelClass:(Class)modelClass error:(NSError * __autoreleasing *)error {
 	NSParameterAssert(modelClass != nil);
 	NSParameterAssert([modelClass conformsToProtocol:@protocol(MTLJSONSerializing)]);
 

--- a/Mantle/MTLModel.h
+++ b/Mantle/MTLModel.h
@@ -48,7 +48,7 @@ typedef enum : NSUInteger {
 ///                   (like a KVC validation error).
 ///
 /// Returns an initialized model object, or nil if validation failed.
-+ (instancetype)modelWithDictionary:(NSDictionary *)dictionaryValue error:(NSError **)error;
++ (instancetype)modelWithDictionary:(NSDictionary *)dictionaryValue error:(NSError * __autoreleasing *)error;
 
 /// A dictionary representing the properties of the receiver.
 ///
@@ -74,7 +74,7 @@ typedef enum : NSUInteger {
 ///                   (like a KVC validation error).
 ///
 /// Returns an initialized model object, or nil if validation failed.
-- (instancetype)initWithDictionary:(NSDictionary *)dictionaryValue error:(NSError **)error;
+- (instancetype)initWithDictionary:(NSDictionary *)dictionaryValue error:(NSError * __autoreleasing *)error;
 
 /// Merges the value of the given key on the receiver with the value of the same
 /// key from the given model object, giving precedence to the other model object.
@@ -90,7 +90,7 @@ typedef enum : NSUInteger {
 ///         validation
 ///
 /// Returns YES if the model is valid, or NO if the validation failed.
-- (BOOL)validate:(NSError **)error;
+- (BOOL)validate:(NSError * __autoreleasing *)error;
 
 @end
 
@@ -113,7 +113,7 @@ typedef enum : NSUInteger {
 ///                   (like a KVC validation error).
 ///
 /// Returns an initialized model object, or nil if validation failed.
-- (instancetype)initWithDictionary:(NSDictionary *)dictionaryValue error:(NSError **)error;
+- (instancetype)initWithDictionary:(NSDictionary *)dictionaryValue error:(NSError * __autoreleasing *)error;
 
 /// Initializes the receiver with default values.
 ///
@@ -174,6 +174,6 @@ typedef enum : NSUInteger {
 ///         validation
 ///
 /// Returns YES if the model is valid, or NO if the validation failed.
-- (BOOL)validate:(NSError **)error;
+- (BOOL)validate:(NSError * __autoreleasing *)error;
 
 @end

--- a/Mantle/MTLModel.m
+++ b/Mantle/MTLModel.m
@@ -120,7 +120,7 @@ static BOOL MTLValidateAndSetValue(id obj, NSString *key, id value, BOOL forceUp
 	objc_setAssociatedObject(self, MTLModelCachedPermanentPropertyKeysKey, permanentKeys, OBJC_ASSOCIATION_COPY);
 }
 
-+ (instancetype)modelWithDictionary:(NSDictionary *)dictionary error:(NSError **)error {
++ (instancetype)modelWithDictionary:(NSDictionary *)dictionary error:(NSError * __autoreleasing *)error {
 	return [[self alloc] initWithDictionary:dictionary error:error];
 }
 
@@ -129,7 +129,7 @@ static BOOL MTLValidateAndSetValue(id obj, NSString *key, id value, BOOL forceUp
 	return [super init];
 }
 
-- (instancetype)initWithDictionary:(NSDictionary *)dictionary error:(NSError **)error {
+- (instancetype)initWithDictionary:(NSDictionary *)dictionary error:(NSError * __autoreleasing *)error {
 	self = [self init];
 	if (self == nil) return nil;
 
@@ -279,7 +279,7 @@ static BOOL MTLValidateAndSetValue(id obj, NSString *key, id value, BOOL forceUp
 
 #pragma mark Validation
 
-- (BOOL)validate:(NSError **)error {
+- (BOOL)validate:(NSError * __autoreleasing *)error {
 	for (NSString *key in self.class.propertyKeys) {
 		id value = [self valueForKey:key];
 

--- a/Mantle/MTLModel.m
+++ b/Mantle/MTLModel.m
@@ -38,7 +38,7 @@ static void *MTLModelCachedPermanentPropertyKeysKey = &MTLModelCachedPermanentPr
 //
 // Returns YES if `value` could be validated and set, or NO if an error
 // occurred.
-static BOOL MTLValidateAndSetValue(id obj, NSString *key, id value, BOOL forceUpdate, NSError **error) {
+static BOOL MTLValidateAndSetValue(id obj, NSString *key, id value, BOOL forceUpdate, NSError * __autoreleasing *error) {
 	// Mark this as being autoreleased, because validateValue may return
 	// a new object to be stored in this variable (and we don't want ARC to
 	// double-free or leak the old or new values).

--- a/Mantle/MTLTransformerErrorHandling.h
+++ b/Mantle/MTLTransformerErrorHandling.h
@@ -42,7 +42,7 @@ extern NSString * const MTLTransformerErrorHandlingInputValueErrorKey;
 ///
 /// Returns the result of the transformation which may be nil. Clients should
 /// inspect the success parameter to decide how to proceed with the result.
-- (id)transformedValue:(id)value success:(BOOL *)success error:(NSError **)error;
+- (id)transformedValue:(id)value success:(BOOL *)success error:(NSError * __autoreleasing *)error;
 
 @optional
 
@@ -61,6 +61,6 @@ extern NSString * const MTLTransformerErrorHandlingInputValueErrorKey;
 /// Returns the result of the reverse transformation which may be nil. Clients
 /// should inspect the success parameter to decide how to proceed with the
 /// result.
-- (id)reverseTransformedValue:(id)value success:(BOOL *)success error:(NSError **)error;
+- (id)reverseTransformedValue:(id)value success:(BOOL *)success error:(NSError * __autoreleasing *)error;
 
 @end

--- a/Mantle/MTLValueTransformer.h
+++ b/Mantle/MTLValueTransformer.h
@@ -21,7 +21,7 @@
 ///           transforming the value.
 ///
 /// Returns the result of the transformation, which may be nil.
-typedef id (^MTLValueTransformerBlock)(id value, BOOL *success, NSError **error);
+typedef id (^MTLValueTransformerBlock)(id value, BOOL *success, NSError * __autoreleasing *error);
 
 ///
 /// A value transformer supporting block-based transformation.

--- a/Mantle/MTLValueTransformer.m
+++ b/Mantle/MTLValueTransformer.m
@@ -67,7 +67,7 @@
 	return self.forwardBlock(value, &success, &error);
 }
 
-- (id)transformedValue:(id)value success:(BOOL *)outerSuccess error:(NSError **)outerError {
+- (id)transformedValue:(id)value success:(BOOL *)outerSuccess error:(NSError * __autoreleasing *)outerError {
 	NSError *error = nil;
 	BOOL success = YES;
 
@@ -103,7 +103,7 @@
 	return self.reverseBlock(value, &success, &error);
 }
 
-- (id)reverseTransformedValue:(id)value success:(BOOL *)outerSuccess error:(NSError **)outerError {
+- (id)reverseTransformedValue:(id)value success:(BOOL *)outerSuccess error:(NSError * __autoreleasing *)outerError {
 	NSError *error = nil;
 	BOOL success = YES;
 
@@ -124,23 +124,23 @@
 #pragma clang diagnostic ignored "-Wdeprecated-implementations"
 
 + (instancetype)transformerWithBlock:(id (^)(id))transformationBlock {
-	return [self transformerUsingForwardBlock:^(id value, BOOL *success, NSError **error) {
+	return [self transformerUsingForwardBlock:^(id value, BOOL *success, NSError * __autoreleasing *error) {
 		return transformationBlock(value);
 	}];
 }
 
 + (instancetype)reversibleTransformerWithBlock:(id (^)(id))transformationBlock {
-	return [self transformerUsingReversibleBlock:^(id value, BOOL *success, NSError **error) {
+	return [self transformerUsingReversibleBlock:^(id value, BOOL *success, NSError * __autoreleasing *error) {
 		return transformationBlock(value);
 	}];
 }
 
 + (instancetype)reversibleTransformerWithForwardBlock:(id (^)(id))forwardBlock reverseBlock:(id (^)(id))reverseBlock {
 	return [self
-		transformerUsingForwardBlock:^(id value, BOOL *success, NSError **error) {
+		transformerUsingForwardBlock:^(id value, BOOL *success, NSError * __autoreleasing *error) {
 			return forwardBlock(value);
 		}
-		reverseBlock:^(id value, BOOL *success, NSError **error) {
+		reverseBlock:^(id value, BOOL *success, NSError * __autoreleasing *error) {
 			return reverseBlock(value);
 		}];
 }

--- a/Mantle/NSDictionary+MTLJSONKeyPath.h
+++ b/Mantle/NSDictionary+MTLJSONKeyPath.h
@@ -22,6 +22,6 @@
 ///
 /// Returns the value for the key path which may be nil. Clients should inspect
 /// the success parameter to decide how to proceed with the result.
-- (id)mtl_valueForJSONKeyPath:(NSString *)JSONKeyPath success:(BOOL *)success error:(NSError **)error;
+- (id)mtl_valueForJSONKeyPath:(NSString *)JSONKeyPath success:(BOOL *)success error:(NSError * __autoreleasing *)error;
 
 @end

--- a/Mantle/NSDictionary+MTLJSONKeyPath.m
+++ b/Mantle/NSDictionary+MTLJSONKeyPath.m
@@ -12,7 +12,7 @@
 
 @implementation NSDictionary (MTLJSONKeyPath)
 
-- (id)mtl_valueForJSONKeyPath:(NSString *)JSONKeyPath success:(BOOL *)success error:(NSError **)error {
+- (id)mtl_valueForJSONKeyPath:(NSString *)JSONKeyPath success:(BOOL *)success error:(NSError * __autoreleasing *)error {
 	NSArray *components = [JSONKeyPath componentsSeparatedByString:@"."];
 
 	id result = self;

--- a/Mantle/NSValueTransformer+MTLInversionAdditions.m
+++ b/Mantle/NSValueTransformer+MTLInversionAdditions.m
@@ -20,15 +20,15 @@
 
 		id<MTLTransformerErrorHandling> errorHandlingSelf = (id)self;
 
-		return [MTLValueTransformer transformerUsingForwardBlock:^(id value, BOOL *success, NSError **error) {
+		return [MTLValueTransformer transformerUsingForwardBlock:^(id value, BOOL *success, NSError * __autoreleasing *error) {
 			return [errorHandlingSelf reverseTransformedValue:value success:success error:error];
-		} reverseBlock:^(id value, BOOL *success, NSError **error) {
+		} reverseBlock:^(id value, BOOL *success, NSError * __autoreleasing *error) {
 			return [errorHandlingSelf transformedValue:value success:success error:error];
 		}];
 	} else {
-		return [MTLValueTransformer transformerUsingForwardBlock:^(id value, BOOL *success, NSError **error) {
+		return [MTLValueTransformer transformerUsingForwardBlock:^(id value, BOOL *success, NSError * __autoreleasing *error) {
 			return [self reverseTransformedValue:value];
-		} reverseBlock:^(id value, BOOL *success, NSError **error) {
+		} reverseBlock:^(id value, BOOL *success, NSError * __autoreleasing *error) {
 			return [self transformedValue:value];
 		}];
 	}

--- a/Mantle/NSValueTransformer+MTLPredefinedTransformerAdditions.m
+++ b/Mantle/NSValueTransformer+MTLPredefinedTransformerAdditions.m
@@ -22,7 +22,7 @@ NSString * const MTLBooleanValueTransformerName = @"MTLBooleanValueTransformerNa
 + (void)load {
 	@autoreleasepool {
 		MTLValueTransformer *URLValueTransformer = [MTLValueTransformer
-			transformerUsingForwardBlock:^ id (NSString *str, BOOL *success, NSError **error) {
+			transformerUsingForwardBlock:^ id (NSString *str, BOOL *success, NSError * __autoreleasing *error) {
 				if (str == nil) return nil;
 
 				if (![str isKindOfClass:NSString.class]) {
@@ -57,7 +57,7 @@ NSString * const MTLBooleanValueTransformerName = @"MTLBooleanValueTransformerNa
 
 				return result;
 			}
-			reverseBlock:^ id (NSURL *URL, BOOL *success, NSError **error) {
+			reverseBlock:^ id (NSURL *URL, BOOL *success, NSError * __autoreleasing *error) {
 				if (URL == nil) return nil;
 
 				if (![URL isKindOfClass:NSURL.class]) {
@@ -79,7 +79,7 @@ NSString * const MTLBooleanValueTransformerName = @"MTLBooleanValueTransformerNa
 		[NSValueTransformer setValueTransformer:URLValueTransformer forName:MTLURLValueTransformerName];
 
 		MTLValueTransformer *UUIDValueTransformer = [MTLValueTransformer
-				transformerUsingForwardBlock:^id(NSString *string, BOOL *success, NSError **error) {
+				transformerUsingForwardBlock:^id(NSString *string, BOOL *success, NSError * __autoreleasing *error) {
 					if (string == nil) return nil;
 					
 					if (![string isKindOfClass:NSString.class]) {
@@ -112,7 +112,7 @@ NSString * const MTLBooleanValueTransformerName = @"MTLBooleanValueTransformerNa
 					
 					return result;
 				}
-				reverseBlock:^id(NSUUID *uuid, BOOL *success, NSError **error) {
+				reverseBlock:^id(NSUUID *uuid, BOOL *success, NSError * __autoreleasing *error) {
 					if (uuid == nil) return nil;
 					
 					if (![uuid isKindOfClass:NSUUID.class]) {
@@ -132,7 +132,7 @@ NSString * const MTLBooleanValueTransformerName = @"MTLBooleanValueTransformerNa
 		[NSValueTransformer setValueTransformer:UUIDValueTransformer forName:MTLUUIDValueTransformerName];
 		
 		MTLValueTransformer *booleanValueTransformer = [MTLValueTransformer
-			transformerUsingReversibleBlock:^ id (NSNumber *boolean, BOOL *success, NSError **error) {
+			transformerUsingReversibleBlock:^ id (NSNumber *boolean, BOOL *success, NSError * __autoreleasing *error) {
 				if (boolean == nil) return nil;
 
 				if (![boolean isKindOfClass:NSNumber.class]) {
@@ -160,7 +160,7 @@ NSString * const MTLBooleanValueTransformerName = @"MTLBooleanValueTransformerNa
 + (NSValueTransformer<MTLTransformerErrorHandling> *)mtl_arrayMappingTransformerWithTransformer:(NSValueTransformer *)transformer {
 	NSParameterAssert(transformer != nil);
 	
-	id (^forwardBlock)(NSArray *values, BOOL *success, NSError **error) = ^ id (NSArray *values, BOOL *success, NSError **error) {
+	id (^forwardBlock)(NSArray *values, BOOL *success, NSError * __autoreleasing *error) = ^ id (NSArray *values, BOOL *success, NSError * __autoreleasing *error) {
 		if (values == nil) return nil;
 		
 		if (![values isKindOfClass:NSArray.class]) {
@@ -216,9 +216,9 @@ NSString * const MTLBooleanValueTransformerName = @"MTLBooleanValueTransformerNa
 		return transformedValues;
 	};
 	
-	id (^reverseBlock)(NSArray *values, BOOL *success, NSError **error) = nil;
+	id (^reverseBlock)(NSArray *values, BOOL *success, NSError * __autoreleasing *error) = nil;
 	if (transformer.class.allowsReverseTransformation) {
-		reverseBlock = ^ id (NSArray *values, BOOL *success, NSError **error) {
+		reverseBlock = ^ id (NSArray *values, BOOL *success, NSError * __autoreleasing *error) {
 			if (values == nil) return nil;
 			
 			if (![values isKindOfClass:NSArray.class]) {
@@ -285,7 +285,7 @@ NSString * const MTLBooleanValueTransformerName = @"MTLBooleanValueTransformerNa
 + (NSValueTransformer<MTLTransformerErrorHandling> *)mtl_validatingTransformerForClass:(Class)modelClass {
 	NSParameterAssert(modelClass != nil);
 
-	return [MTLValueTransformer transformerUsingForwardBlock:^ id (id value, BOOL *success, NSError **error) {
+	return [MTLValueTransformer transformerUsingForwardBlock:^ id (id value, BOOL *success, NSError * __autoreleasing *error) {
 		if (value != nil && ![value isKindOfClass:modelClass]) {
 			if (error != NULL) {
 				NSDictionary *userInfo = @{
@@ -309,10 +309,10 @@ NSString * const MTLBooleanValueTransformerName = @"MTLBooleanValueTransformerNa
 	NSParameterAssert(dictionary.count == [[NSSet setWithArray:dictionary.allValues] count]);
 
 	return [MTLValueTransformer
-			transformerUsingForwardBlock:^ id (id <NSCopying> key, BOOL *success, NSError **error) {
+			transformerUsingForwardBlock:^ id (id <NSCopying> key, BOOL *success, NSError * __autoreleasing *error) {
 				return dictionary[key ?: NSNull.null] ?: defaultValue;
 			}
-			reverseBlock:^ id (id value, BOOL *success, NSError **error) {
+			reverseBlock:^ id (id value, BOOL *success, NSError * __autoreleasing *error) {
 				__block id result = nil;
 				[dictionary enumerateKeysAndObjectsUsingBlock:^(id key, id anObject, BOOL *stop) {
 					if ([value isEqual:anObject]) {

--- a/MantleTests/MTLPredefinedTransformerAdditionsSpec.m
+++ b/MantleTests/MTLPredefinedTransformerAdditionsSpec.m
@@ -154,7 +154,7 @@ describe(@"+mtl_arrayMappingTransformerWithTransformer:", ^{
 
 	describe(@"when called with a non-reversible transformer", ^{
 		beforeEach(^{
-			NSValueTransformer *appliedTransformer = [MTLValueTransformer transformerUsingForwardBlock:^(NSString *str, BOOL *success, NSError **error) {
+			NSValueTransformer *appliedTransformer = [MTLValueTransformer transformerUsingForwardBlock:^(NSString *str, BOOL *success, NSError * __autoreleasing *error) {
 				return [NSURL URLWithString:str];
 			}];
 			transformer = [NSValueTransformer mtl_arrayMappingTransformerWithTransformer:appliedTransformer];

--- a/MantleTests/MTLTestJSONAdapter.m
+++ b/MantleTests/MTLTestJSONAdapter.m
@@ -18,7 +18,7 @@
 	return copy;
 }
 
-- (NSDictionary *)JSONDictionaryFromModel:(id<MTLJSONSerializing>)model error:(NSError **)error {
+- (NSDictionary *)JSONDictionaryFromModel:(id<MTLJSONSerializing>)model error:(NSError * __autoreleasing *)error {
 	NSDictionary *dictionary = [super JSONDictionaryFromModel:model error:error];
 	return [dictionary mtl_dictionaryByAddingEntriesFromDictionary:@{
 		@"test": @YES

--- a/MantleTests/MTLTestModel.m
+++ b/MantleTests/MTLTestModel.m
@@ -24,7 +24,7 @@ static NSUInteger modelVersion = 1;
 
 #pragma mark Properties
 
-- (BOOL)validateName:(NSString **)name error:(NSError * __autoreleasing *)error {
+- (BOOL)validateName:(NSString * __autoreleasing *)name error:(NSError * __autoreleasing *)error {
 	if ([*name length] < 10) return YES;
 	if (error != NULL) {
 		*error = [NSError errorWithDomain:MTLTestModelErrorDomain code:MTLTestModelNameTooLong userInfo:nil];
@@ -176,7 +176,7 @@ static NSUInteger modelVersion = 1;
 	};
 }
 
-- (BOOL)validateName:(NSString **)name error:(NSError * __autoreleasing *)error {
+- (BOOL)validateName:(NSString * __autoreleasing *)name error:(NSError * __autoreleasing *)error {
 	if (*name != nil) return YES;
 	if (error != NULL) {
 		*error = [NSError errorWithDomain:MTLTestModelErrorDomain code:MTLTestModelNameMissing userInfo:nil];
@@ -189,7 +189,7 @@ static NSUInteger modelVersion = 1;
 
 @implementation MTLSelfValidatingModel
 
-- (BOOL)validateName:(NSString **)name error:(NSError * __autoreleasing *)error {
+- (BOOL)validateName:(NSString * __autoreleasing *)name error:(NSError * __autoreleasing *)error {
 	if (*name != nil) return YES;
 
 	*name = @"foobar";

--- a/MantleTests/MTLTestModel.m
+++ b/MantleTests/MTLTestModel.m
@@ -24,7 +24,7 @@ static NSUInteger modelVersion = 1;
 
 #pragma mark Properties
 
-- (BOOL)validateName:(NSString **)name error:(NSError **)error {
+- (BOOL)validateName:(NSString **)name error:(NSError * __autoreleasing *)error {
 	if ([*name length] < 10) return YES;
 	if (error != NULL) {
 		*error = [NSError errorWithDomain:MTLTestModelErrorDomain code:MTLTestModelNameTooLong userInfo:nil];
@@ -176,7 +176,7 @@ static NSUInteger modelVersion = 1;
 	};
 }
 
-- (BOOL)validateName:(NSString **)name error:(NSError **)error {
+- (BOOL)validateName:(NSString **)name error:(NSError * __autoreleasing *)error {
 	if (*name != nil) return YES;
 	if (error != NULL) {
 		*error = [NSError errorWithDomain:MTLTestModelErrorDomain code:MTLTestModelNameMissing userInfo:nil];
@@ -189,7 +189,7 @@ static NSUInteger modelVersion = 1;
 
 @implementation MTLSelfValidatingModel
 
-- (BOOL)validateName:(NSString **)name error:(NSError **)error {
+- (BOOL)validateName:(NSString **)name error:(NSError * __autoreleasing *)error {
 	if (*name != nil) return YES;
 
 	*name = @"foobar";
@@ -323,7 +323,7 @@ static NSUInteger modelVersion = 1;
 
 @interface MTLConformingModel ()
 
-- (instancetype)initWithDictionary:(NSDictionary *)dictionaryValue error:(NSError **)error;
+- (instancetype)initWithDictionary:(NSDictionary *)dictionaryValue error:(NSError * __autoreleasing *)error;
 
 @end
 
@@ -331,11 +331,11 @@ static NSUInteger modelVersion = 1;
 
 #pragma mark Lifecycle
 
-+ (instancetype)modelWithDictionary:(NSDictionary *)dictionaryValue error:(NSError **)error {
++ (instancetype)modelWithDictionary:(NSDictionary *)dictionaryValue error:(NSError * __autoreleasing *)error {
 	return [[self alloc] initWithDictionary:dictionaryValue error:error];
 }
 
-- (instancetype)initWithDictionary:(NSDictionary *)dictionaryValue error:(NSError **)error {
+- (instancetype)initWithDictionary:(NSDictionary *)dictionaryValue error:(NSError * __autoreleasing *)error {
 	self = [super init];
 	if (self == nil) return nil;
 
@@ -344,7 +344,7 @@ static NSUInteger modelVersion = 1;
 	return self;
 }
 
-- (BOOL)validate:(NSError **)error {
+- (BOOL)validate:(NSError * __autoreleasing *)error {
 	return YES;
 }
 

--- a/MantleTests/MTLTestModel.m
+++ b/MantleTests/MTLTestModel.m
@@ -73,10 +73,10 @@ static NSUInteger modelVersion = 1;
 
 + (NSValueTransformer *)countJSONTransformer {
 	return [MTLValueTransformer
-		transformerUsingForwardBlock:^(NSString *str, BOOL *success, NSError **error) {
+		transformerUsingForwardBlock:^(NSString *str, BOOL *success, NSError * __autoreleasing *error) {
 			return @(str.integerValue);
 		}
-		reverseBlock:^(NSNumber *num, BOOL *success, NSError **error) {
+		reverseBlock:^(NSNumber *num, BOOL *success, NSError * __autoreleasing *error) {
 			return num.stringValue;
 		}];
 }
@@ -428,12 +428,12 @@ static NSUInteger modelVersion = 1;
 
 + (NSValueTransformer *)rangeJSONTransformer {
 	return [MTLValueTransformer
-		transformerUsingForwardBlock:^(NSDictionary *value, BOOL *success, NSError **error) {
+		transformerUsingForwardBlock:^(NSDictionary *value, BOOL *success, NSError * __autoreleasing *error) {
 			NSUInteger location = [value[@"location"] unsignedIntegerValue];
 			NSUInteger length = [value[@"length"] unsignedIntegerValue];
 
 			return [NSValue valueWithRange:NSMakeRange(location, length)];
-		} reverseBlock:^(NSValue *value, BOOL *success, NSError **error) {
+		} reverseBlock:^(NSValue *value, BOOL *success, NSError * __autoreleasing *error) {
 			NSRange range = value.rangeValue;
 
 			return @{
@@ -445,12 +445,12 @@ static NSUInteger modelVersion = 1;
 
 + (NSValueTransformer *)nestedRangeJSONTransformer {
 	return [MTLValueTransformer
-		transformerUsingForwardBlock:^(NSDictionary *value, BOOL *success, NSError **error) {
+		transformerUsingForwardBlock:^(NSDictionary *value, BOOL *success, NSError * __autoreleasing *error) {
 			NSUInteger location = [value[@"nested.location"] unsignedIntegerValue];
 			NSUInteger length = [value[@"nested.length"] unsignedIntegerValue];
 
 			return [NSValue valueWithRange:NSMakeRange(location, length)];
-		} reverseBlock:^(NSValue *value, BOOL *success, NSError **error) {
+		} reverseBlock:^(NSValue *value, BOOL *success, NSError * __autoreleasing *error) {
 			NSRange range = value.rangeValue;
 
 			return @{
@@ -497,12 +497,12 @@ static NSUInteger modelVersion = 1;
 
 + (NSValueTransformer *)bitternessJSONTransformer {
 	return [MTLValueTransformer
-		transformerUsingForwardBlock:^(NSString *string, BOOL *success, NSError **error) {
+		transformerUsingForwardBlock:^(NSString *string, BOOL *success, NSError * __autoreleasing *error) {
 			NSNumberFormatter *formatter = [[NSNumberFormatter alloc] init];
 
 			return [formatter numberFromString:string];
 		}
-		reverseBlock:^(NSNumber *value, BOOL *success, NSError **error) {
+		reverseBlock:^(NSNumber *value, BOOL *success, NSError * __autoreleasing *error) {
 			return [value description];
 		}];
 }

--- a/MantleTests/MTLValueTransformerSpec.m
+++ b/MantleTests/MTLValueTransformerSpec.m
@@ -13,7 +13,7 @@
 QuickSpecBegin(MTLValueTransformerSpec)
 
 it(@"should return a forward transformer with a block", ^{
-	MTLValueTransformer *transformer = [MTLValueTransformer transformerUsingForwardBlock:^(NSString *str, BOOL *success, NSError **error) {
+	MTLValueTransformer *transformer = [MTLValueTransformer transformerUsingForwardBlock:^(NSString *str, BOOL *success, NSError * __autoreleasing *error) {
 		return [str stringByAppendingString:@"bar"];
 	}];
 
@@ -25,7 +25,7 @@ it(@"should return a forward transformer with a block", ^{
 });
 
 it(@"should return a reversible transformer with a block", ^{
-	MTLValueTransformer *transformer = [MTLValueTransformer transformerUsingReversibleBlock:^(NSString *str, BOOL *success, NSError **error) {
+	MTLValueTransformer *transformer = [MTLValueTransformer transformerUsingReversibleBlock:^(NSString *str, BOOL *success, NSError * __autoreleasing *error) {
 		return [str stringByAppendingString:@"bar"];
 	}];
 
@@ -38,10 +38,10 @@ it(@"should return a reversible transformer with a block", ^{
 
 it(@"should return a reversible transformer with forward and reverse blocks", ^{
 	MTLValueTransformer *transformer = [MTLValueTransformer
-		transformerUsingForwardBlock:^(NSString *str, BOOL *success, NSError **error) {
+		transformerUsingForwardBlock:^(NSString *str, BOOL *success, NSError * __autoreleasing *error) {
 			return [str stringByAppendingString:@"bar"];
 		}
-		reverseBlock:^(NSString *str, BOOL *success, NSError **error) {
+		reverseBlock:^(NSString *str, BOOL *success, NSError * __autoreleasing *error) {
 			return [str substringToIndex:str.length - 3];
 		}];
 


### PR DESCRIPTION
When indirect assignment to error, ARC needs to know the mode of the referenced variable so it knows how to read and write. That is why we need the __autoreleasing is in the declaration, it tells ARC that it has been passed a reference to a variable whose mode is autoreleasing, and that tells ARC how to read and write the contents of the variable. Without  __autoreleasing a default mode will be assumed, and in this case I'd suggest explicitly tell  ARC what to do .
