### PR TITLE
Add support for JSON keys with dots with MTLJSONKeyPath

### DIFF
--- a/Mantle.xcodeproj/project.pbxproj
+++ b/Mantle.xcodeproj/project.pbxproj
@@ -24,12 +24,27 @@
 		A18397E61BA341D300AB37BA /* EXTScope.h in Headers */ = {isa = PBXBuildFile; fileRef = D094E4781777617300906BF7 /* EXTScope.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		A18397E71BA341D900AB37BA /* metamacros.h in Headers */ = {isa = PBXBuildFile; fileRef = D094E47A1777617300906BF7 /* metamacros.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		A18397E81BA341DC00AB37BA /* metamacros.h in Headers */ = {isa = PBXBuildFile; fileRef = D094E47A1777617300906BF7 /* metamacros.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		BE298E4A1E8EF4F6003A9848 /* MTLJSONKeyPath.h in Headers */ = {isa = PBXBuildFile; fileRef = BE298E481E8EF4F6003A9848 /* MTLJSONKeyPath.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BE298E4B1E8EF4F6003A9848 /* MTLJSONKeyPath.m in Sources */ = {isa = PBXBuildFile; fileRef = BE298E491E8EF4F6003A9848 /* MTLJSONKeyPath.m */; };
 		BE3408E1196591F300C6C145 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D0A56B581804B04900A84EDC /* XCTest.framework */; };
+		BE788B2F1E8F358100727A91 /* NSDictionary+MTLJSONKeyPath.h in Headers */ = {isa = PBXBuildFile; fileRef = 54EDCD0818D9B34F005796FC /* NSDictionary+MTLJSONKeyPath.h */; };
+		BE788B301E8F358200727A91 /* NSDictionary+MTLJSONKeyPath.h in Headers */ = {isa = PBXBuildFile; fileRef = 54EDCD0818D9B34F005796FC /* NSDictionary+MTLJSONKeyPath.h */; };
+		BE788B311E8F358300727A91 /* NSDictionary+MTLJSONKeyPath.h in Headers */ = {isa = PBXBuildFile; fileRef = 54EDCD0818D9B34F005796FC /* NSDictionary+MTLJSONKeyPath.h */; };
+		BE788B321E8F358300727A91 /* NSDictionary+MTLJSONKeyPath.h in Headers */ = {isa = PBXBuildFile; fileRef = 54EDCD0818D9B34F005796FC /* NSDictionary+MTLJSONKeyPath.h */; };
+		BE788B331E8F35B400727A91 /* NSDictionary+MTLJSONKeyPath.m in Sources */ = {isa = PBXBuildFile; fileRef = 54EDCD0918D9B34F005796FC /* NSDictionary+MTLJSONKeyPath.m */; };
+		BE788B341E8F35B600727A91 /* NSDictionary+MTLJSONKeyPath.m in Sources */ = {isa = PBXBuildFile; fileRef = 54EDCD0918D9B34F005796FC /* NSDictionary+MTLJSONKeyPath.m */; };
+		BE788B351E8F35B700727A91 /* NSDictionary+MTLJSONKeyPath.m in Sources */ = {isa = PBXBuildFile; fileRef = 54EDCD0918D9B34F005796FC /* NSDictionary+MTLJSONKeyPath.m */; };
+		BE788B361E8F35B800727A91 /* NSDictionary+MTLJSONKeyPath.m in Sources */ = {isa = PBXBuildFile; fileRef = 54EDCD0918D9B34F005796FC /* NSDictionary+MTLJSONKeyPath.m */; };
+		BE788B371E8F360B00727A91 /* MTLJSONKeyPath.m in Sources */ = {isa = PBXBuildFile; fileRef = BE298E491E8EF4F6003A9848 /* MTLJSONKeyPath.m */; };
+		BE788B381E8F361000727A91 /* MTLJSONKeyPath.m in Sources */ = {isa = PBXBuildFile; fileRef = BE298E491E8EF4F6003A9848 /* MTLJSONKeyPath.m */; };
+		BE788B391E8F361400727A91 /* MTLJSONKeyPath.m in Sources */ = {isa = PBXBuildFile; fileRef = BE298E491E8EF4F6003A9848 /* MTLJSONKeyPath.m */; };
+		BEC058161E8EF888006F5A1D /* MTLJSONKeyPath.h in Headers */ = {isa = PBXBuildFile; fileRef = BE298E481E8EF4F6003A9848 /* MTLJSONKeyPath.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BEC058171E8EF888006F5A1D /* MTLJSONKeyPath.h in Headers */ = {isa = PBXBuildFile; fileRef = BE298E481E8EF4F6003A9848 /* MTLJSONKeyPath.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BEC058181E8EF889006F5A1D /* MTLJSONKeyPath.h in Headers */ = {isa = PBXBuildFile; fileRef = BE298E481E8EF4F6003A9848 /* MTLJSONKeyPath.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CD7C6D8A1D33ACCC002EC294 /* NSError+MTLModelException.m in Sources */ = {isa = PBXBuildFile; fileRef = 54803A31178829A700011B39 /* NSError+MTLModelException.m */; };
 		CD7C6D8B1D33ACCC002EC294 /* NSValueTransformer+MTLPredefinedTransformerAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = D0F117481614C5600092520B /* NSValueTransformer+MTLPredefinedTransformerAdditions.m */; };
 		CD7C6D8C1D33ACCC002EC294 /* NSDictionary+MTLMappingAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 547F78541822BCFD00BBAB7B /* NSDictionary+MTLMappingAdditions.m */; };
 		CD7C6D8D1D33ACCC002EC294 /* MTLReflection.m in Sources */ = {isa = PBXBuildFile; fileRef = D058FE1E16EFB3D2009DFB47 /* MTLReflection.m */; };
-		CD7C6D8E1D33ACCC002EC294 /* NSDictionary+MTLJSONKeyPath.m in Sources */ = {isa = PBXBuildFile; fileRef = 54EDCD0918D9B34F005796FC /* NSDictionary+MTLJSONKeyPath.m */; };
 		CD7C6D8F1D33ACCC002EC294 /* MTLModel+NSCoding.m in Sources */ = {isa = PBXBuildFile; fileRef = D01BD0AE16CB52E800EC95C7 /* MTLModel+NSCoding.m */; };
 		CD7C6D901D33ACCC002EC294 /* NSObject+MTLComparisonAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 1ED5B5CF163A4E3C0072668E /* NSObject+MTLComparisonAdditions.m */; };
 		CD7C6D911D33ACCC002EC294 /* MTLModel.m in Sources */ = {isa = PBXBuildFile; fileRef = D0760E7715FFBF330060F550 /* MTLModel.m */; };
@@ -61,7 +76,6 @@
 		CDEEABAA1D33FC5100240A4B /* NSValueTransformer+MTLPredefinedTransformerAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = D0F117481614C5600092520B /* NSValueTransformer+MTLPredefinedTransformerAdditions.m */; };
 		CDEEABAB1D33FC5100240A4B /* NSDictionary+MTLMappingAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 547F78541822BCFD00BBAB7B /* NSDictionary+MTLMappingAdditions.m */; };
 		CDEEABAC1D33FC5100240A4B /* MTLReflection.m in Sources */ = {isa = PBXBuildFile; fileRef = D058FE1E16EFB3D2009DFB47 /* MTLReflection.m */; };
-		CDEEABAD1D33FC5100240A4B /* NSDictionary+MTLJSONKeyPath.m in Sources */ = {isa = PBXBuildFile; fileRef = 54EDCD0918D9B34F005796FC /* NSDictionary+MTLJSONKeyPath.m */; };
 		CDEEABAE1D33FC5100240A4B /* MTLModel+NSCoding.m in Sources */ = {isa = PBXBuildFile; fileRef = D01BD0AE16CB52E800EC95C7 /* MTLModel+NSCoding.m */; };
 		CDEEABAF1D33FC5100240A4B /* NSObject+MTLComparisonAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 1ED5B5CF163A4E3C0072668E /* NSObject+MTLComparisonAdditions.m */; };
 		CDEEABB01D33FC5100240A4B /* MTLModel.m in Sources */ = {isa = PBXBuildFile; fileRef = D0760E7715FFBF330060F550 /* MTLModel.m */; };
@@ -131,9 +145,7 @@
 		D05317741A168D3D00A5FBE2 /* MTLTransformerErrorHandling.h in Headers */ = {isa = PBXBuildFile; fileRef = 547165A31801977000E734DB /* MTLTransformerErrorHandling.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D05317751A168D3D00A5FBE2 /* MTLTransformerErrorHandling.m in Sources */ = {isa = PBXBuildFile; fileRef = 5487912318210717007F8347 /* MTLTransformerErrorHandling.m */; };
 		D05317761A168D6D00A5FBE2 /* NSDictionary+MTLMappingAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 547F78541822BCFD00BBAB7B /* NSDictionary+MTLMappingAdditions.m */; };
-		D05317771A168D6D00A5FBE2 /* NSDictionary+MTLJSONKeyPath.m in Sources */ = {isa = PBXBuildFile; fileRef = 54EDCD0918D9B34F005796FC /* NSDictionary+MTLJSONKeyPath.m */; };
 		D05317781A168D6D00A5FBE2 /* NSDictionary+MTLMappingAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 547F78541822BCFD00BBAB7B /* NSDictionary+MTLMappingAdditions.m */; };
-		D05317791A168D6D00A5FBE2 /* NSDictionary+MTLJSONKeyPath.m in Sources */ = {isa = PBXBuildFile; fileRef = 54EDCD0918D9B34F005796FC /* NSDictionary+MTLJSONKeyPath.m */; };
 		D053177A1A168D7100A5FBE2 /* NSDictionary+MTLMappingAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 547F78531822BCFD00BBAB7B /* NSDictionary+MTLMappingAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D053177B1A168D7200A5FBE2 /* NSDictionary+MTLMappingAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 547F78531822BCFD00BBAB7B /* NSDictionary+MTLMappingAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D053177E1A168F8B00A5FBE2 /* MTLTestJSONAdapter.m in Sources */ = {isa = PBXBuildFile; fileRef = D053177D1A168F8B00A5FBE2 /* MTLTestJSONAdapter.m */; };
@@ -283,6 +295,8 @@
 		88080C16160A706900CCABF2 /* NSArray+MTLManipulationAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSArray+MTLManipulationAdditions.h"; sourceTree = "<group>"; };
 		88080C17160A706900CCABF2 /* NSArray+MTLManipulationAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSArray+MTLManipulationAdditions.m"; sourceTree = "<group>"; };
 		88080C1C160A719D00CCABF2 /* MTLArrayManipulationSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MTLArrayManipulationSpec.m; sourceTree = "<group>"; };
+		BE298E481E8EF4F6003A9848 /* MTLJSONKeyPath.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MTLJSONKeyPath.h; sourceTree = "<group>"; };
+		BE298E491E8EF4F6003A9848 /* MTLJSONKeyPath.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MTLJSONKeyPath.m; sourceTree = "<group>"; };
 		CD7C6DB21D33ACCC002EC294 /* Mantle.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Mantle.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CD7C6DB51D33AD72002EC294 /* watchOS-Application.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = "watchOS-Application.xcconfig"; path = "watchOS/watchOS-Application.xcconfig"; sourceTree = "<group>"; };
 		CD7C6DB61D33AD72002EC294 /* watchOS-Base.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = "watchOS-Base.xcconfig"; path = "watchOS/watchOS-Base.xcconfig"; sourceTree = "<group>"; };
@@ -563,6 +577,8 @@
 				D0760E7715FFBF330060F550 /* MTLModel.m */,
 				D01BD0AD16CB52E800EC95C7 /* MTLModel+NSCoding.h */,
 				D01BD0AE16CB52E800EC95C7 /* MTLModel+NSCoding.m */,
+				BE298E481E8EF4F6003A9848 /* MTLJSONKeyPath.h */,
+				BE298E491E8EF4F6003A9848 /* MTLJSONKeyPath.m */,
 				D058FE1D16EFB3D2009DFB47 /* MTLReflection.h */,
 				D058FE1E16EFB3D2009DFB47 /* MTLReflection.m */,
 				D01BD0AB16CB46B600EC95C7 /* Adapters */,
@@ -715,7 +731,9 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BE788B321E8F358300727A91 /* NSDictionary+MTLJSONKeyPath.h in Headers */,
 				CD7C6D9C1D33ACCC002EC294 /* NSArray+MTLManipulationAdditions.h in Headers */,
+				BEC058181E8EF889006F5A1D /* MTLJSONKeyPath.h in Headers */,
 				CD7C6D9D1D33ACCC002EC294 /* MTLModel+NSCoding.h in Headers */,
 				CD7C6D9E1D33ACCC002EC294 /* NSObject+MTLComparisonAdditions.h in Headers */,
 				CD7C6D9F1D33ACCC002EC294 /* EXTKeyPathCoding.h in Headers */,
@@ -738,7 +756,9 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BE788B311E8F358300727A91 /* NSDictionary+MTLJSONKeyPath.h in Headers */,
 				CDEEABBB1D33FC5100240A4B /* NSArray+MTLManipulationAdditions.h in Headers */,
+				BEC058171E8EF888006F5A1D /* MTLJSONKeyPath.h in Headers */,
 				CDEEABBC1D33FC5100240A4B /* MTLModel+NSCoding.h in Headers */,
 				CDEEABBD1D33FC5100240A4B /* NSObject+MTLComparisonAdditions.h in Headers */,
 				CDEEABBE1D33FC5100240A4B /* EXTKeyPathCoding.h in Headers */,
@@ -761,7 +781,9 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BE788B2F1E8F358100727A91 /* NSDictionary+MTLJSONKeyPath.h in Headers */,
 				D0760E0515FFBD440060F550 /* Mantle.h in Headers */,
+				BE298E4A1E8EF4F6003A9848 /* MTLJSONKeyPath.h in Headers */,
 				D0760E7815FFBF330060F550 /* MTLModel.h in Headers */,
 				D08B5AAE16002694001FE685 /* MTLValueTransformer.h in Headers */,
 				A18397E11BA341BC00AB37BA /* EXTKeyPathCoding.h in Headers */,
@@ -784,7 +806,9 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BE788B301E8F358200727A91 /* NSDictionary+MTLJSONKeyPath.h in Headers */,
 				D0E9C38319F6DC5B000D427D /* NSArray+MTLManipulationAdditions.h in Headers */,
+				BEC058161E8EF888006F5A1D /* MTLJSONKeyPath.h in Headers */,
 				D0E9C37919F6DC5B000D427D /* MTLModel+NSCoding.h in Headers */,
 				D0E9C38919F6DC5B000D427D /* NSObject+MTLComparisonAdditions.h in Headers */,
 				A18397E21BA341BF00AB37BA /* EXTKeyPathCoding.h in Headers */,
@@ -1040,14 +1064,15 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BE788B391E8F361400727A91 /* MTLJSONKeyPath.m in Sources */,
 				CD7C6D8A1D33ACCC002EC294 /* NSError+MTLModelException.m in Sources */,
 				CD7C6D8B1D33ACCC002EC294 /* NSValueTransformer+MTLPredefinedTransformerAdditions.m in Sources */,
 				CD7C6D8C1D33ACCC002EC294 /* NSDictionary+MTLMappingAdditions.m in Sources */,
 				CD7C6D8D1D33ACCC002EC294 /* MTLReflection.m in Sources */,
-				CD7C6D8E1D33ACCC002EC294 /* NSDictionary+MTLJSONKeyPath.m in Sources */,
 				CD7C6D8F1D33ACCC002EC294 /* MTLModel+NSCoding.m in Sources */,
 				CD7C6D901D33ACCC002EC294 /* NSObject+MTLComparisonAdditions.m in Sources */,
 				CD7C6D911D33ACCC002EC294 /* MTLModel.m in Sources */,
+				BE788B361E8F35B800727A91 /* NSDictionary+MTLJSONKeyPath.m in Sources */,
 				CD7C6D921D33ACCC002EC294 /* MTLJSONAdapter.m in Sources */,
 				CD7C6D931D33ACCC002EC294 /* NSArray+MTLManipulationAdditions.m in Sources */,
 				CD7C6D941D33ACCC002EC294 /* MTLTransformerErrorHandling.m in Sources */,
@@ -1063,14 +1088,15 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BE788B381E8F361000727A91 /* MTLJSONKeyPath.m in Sources */,
 				CDEEABA91D33FC5100240A4B /* NSError+MTLModelException.m in Sources */,
 				CDEEABAA1D33FC5100240A4B /* NSValueTransformer+MTLPredefinedTransformerAdditions.m in Sources */,
 				CDEEABAB1D33FC5100240A4B /* NSDictionary+MTLMappingAdditions.m in Sources */,
 				CDEEABAC1D33FC5100240A4B /* MTLReflection.m in Sources */,
-				CDEEABAD1D33FC5100240A4B /* NSDictionary+MTLJSONKeyPath.m in Sources */,
 				CDEEABAE1D33FC5100240A4B /* MTLModel+NSCoding.m in Sources */,
 				CDEEABAF1D33FC5100240A4B /* NSObject+MTLComparisonAdditions.m in Sources */,
 				CDEEABB01D33FC5100240A4B /* MTLModel.m in Sources */,
+				BE788B351E8F35B700727A91 /* NSDictionary+MTLJSONKeyPath.m in Sources */,
 				CDEEABB11D33FC5100240A4B /* MTLJSONAdapter.m in Sources */,
 				CDEEABB21D33FC5100240A4B /* NSArray+MTLManipulationAdditions.m in Sources */,
 				CDEEABB31D33FC5100240A4B /* MTLTransformerErrorHandling.m in Sources */,
@@ -1109,14 +1135,15 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BE298E4B1E8EF4F6003A9848 /* MTLJSONKeyPath.m in Sources */,
 				D0760E7915FFBF330060F550 /* MTLModel.m in Sources */,
 				D08B5AAF16002694001FE685 /* MTLValueTransformer.m in Sources */,
 				88080C19160A706900CCABF2 /* NSArray+MTLManipulationAdditions.m in Sources */,
 				D0C27D0B16110973002FE587 /* NSDictionary+MTLManipulationAdditions.m in Sources */,
 				D0F1174A1614C5600092520B /* NSValueTransformer+MTLPredefinedTransformerAdditions.m in Sources */,
+				BE788B331E8F35B400727A91 /* NSDictionary+MTLJSONKeyPath.m in Sources */,
 				D05317731A168D3D00A5FBE2 /* MTLTransformerErrorHandling.m in Sources */,
 				1ED5B5D1163A4E3C0072668E /* NSObject+MTLComparisonAdditions.m in Sources */,
-				D05317771A168D6D00A5FBE2 /* NSDictionary+MTLJSONKeyPath.m in Sources */,
 				D01BD09F16CB432D00EC95C7 /* MTLJSONAdapter.m in Sources */,
 				54803A34178829A800011B39 /* NSError+MTLModelException.m in Sources */,
 				D01BD0B116CB52E800EC95C7 /* MTLModel+NSCoding.m in Sources */,
@@ -1155,14 +1182,15 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BE788B371E8F360B00727A91 /* MTLJSONKeyPath.m in Sources */,
 				D0E9C38619F6DC5B000D427D /* NSError+MTLModelException.m in Sources */,
 				D0E9C38E19F6DC5B000D427D /* NSValueTransformer+MTLPredefinedTransformerAdditions.m in Sources */,
 				D05317781A168D6D00A5FBE2 /* NSDictionary+MTLMappingAdditions.m in Sources */,
 				D0E9C37C19F6DC5B000D427D /* MTLReflection.m in Sources */,
-				D05317791A168D6D00A5FBE2 /* NSDictionary+MTLJSONKeyPath.m in Sources */,
 				D0E9C37A19F6DC5B000D427D /* MTLModel+NSCoding.m in Sources */,
 				D0E9C38A19F6DC5B000D427D /* NSObject+MTLComparisonAdditions.m in Sources */,
 				D0E9C37819F6DC5B000D427D /* MTLModel.m in Sources */,
+				BE788B341E8F35B600727A91 /* NSDictionary+MTLJSONKeyPath.m in Sources */,
 				D0E9C37E19F6DC5B000D427D /* MTLJSONAdapter.m in Sources */,
 				D0E9C38419F6DC5B000D427D /* NSArray+MTLManipulationAdditions.m in Sources */,
 				D05317751A168D3D00A5FBE2 /* MTLTransformerErrorHandling.m in Sources */,

--- a/Mantle/MTLJSONAdapter.h
+++ b/Mantle/MTLJSONAdapter.h
@@ -33,13 +33,15 @@
 ///         return @{
 ///             @"name": @"POI.name",
 ///             @"point": @[ @"latitude", @"longitude" ],
-///             @"starred": @"starred"
+///             @"starred": @"starred",
+///             @"username": MTLKeyPath(@"com.github", @"user", @"username")
 ///         };
 ///     }
 ///
 /// This will map the `starred` property to `JSONDictionary[@"starred"]`, `name`
-/// to `JSONDictionary[@"POI"][@"name"]` and `point` to a dictionary equivalent
-/// to:
+/// to `JSONDictionary[@"POI"][@"name"]`, `username` to
+/// `JSONDictionary[@"com.github"][@"user"][@"username"]`, and `point` to a
+/// dictionary equivalent to:
 ///
 ///     @{
 ///         @"latitude": JSONDictionary[@"latitude"],
@@ -47,7 +49,7 @@
 ///     }
 ///
 /// Returns a dictionary mapping property keys to one or multiple JSON key paths
-/// (as strings or arrays of strings).
+/// (as NSStrings, MTLJSONKeyPaths, or NSArrays of NSStrings or MTLJSONKeyPaths).
 + (NSDictionary *)JSONKeyPathsByPropertyKey;
 
 @optional

--- a/Mantle/MTLJSONAdapter.m
+++ b/Mantle/MTLJSONAdapter.m
@@ -219,7 +219,7 @@ NSString * const MTLJSONAdapterThrownExceptionErrorKey = @"MTLJSONAdapterThrownE
 			}
 		}
 
-		void (^createComponentsAndSetValue)(id, id, id) = ^(NSMutableDictionary *dictionary, id keyPath, id value) {
+		void (^createComponentsAndSetValue)(NSMutableDictionary *, id, id) = ^(NSMutableDictionary *dictionary, id keyPath, id value) {
 			NSArray *keyPathComponents;
 			if ([keyPath isKindOfClass:MTLJSONKeyPath.class]) {
 				keyPathComponents = ((MTLJSONKeyPath *)keyPath).components;

--- a/Mantle/MTLJSONKeyPath.h
+++ b/Mantle/MTLJSONKeyPath.h
@@ -1,0 +1,36 @@
+//
+//  MTLJSONKeyPath.h
+//  Mantle
+//
+//  Created by Will Lisac on 3/31/17.
+//  Copyright © 2017 GitHub. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// A class used to represent a JSON key path by discrete key components.
+@interface MTLJSONKeyPath : NSObject <NSCopying>
+
+/// An array of JSON keys that represent a JSON key path.
+///
+/// This property will never be nil.
+@property (nonatomic, strong, readonly) NSArray<NSString *> *components;
+
+/// Initializes the receiver with the given JSON key components.
+///
+/// components - The array of JSON keys that represent a JSON key path.
+///              This argument must not be nil.
+///
+/// Returns an initialized JSON Key path.
+- (instancetype)initWithComponents:(NSArray<NSString *> *)components;
+
+@end
+
+/// MTLKeyPath is a macro that initializes and returns a MTLJSONKeyPath
+/// object with the given JSON key components.
+#define MTLKeyPath(...) \
+	[[MTLJSONKeyPath alloc] initWithComponents:@[__VA_ARGS__]]
+
+NS_ASSUME_NONNULL_END

--- a/Mantle/MTLJSONKeyPath.m
+++ b/Mantle/MTLJSONKeyPath.m
@@ -1,0 +1,53 @@
+//
+//  MTLJSONKeyPath.m
+//  Mantle
+//
+//  Created by Will Lisac on 3/31/17.
+//  Copyright © 2017 GitHub. All rights reserved.
+//
+
+#import "MTLJSONKeyPath.h"
+
+@interface MTLJSONKeyPath ()
+
+@property (nonatomic, strong, readwrite) NSArray *components;
+
+@end
+
+@implementation MTLJSONKeyPath
+
+- (instancetype)initWithComponents:(NSArray<NSString *> *)components {
+	self = [super init];
+	if (self == nil) return nil;
+	
+	self.components = components;
+	
+	return self;
+}
+
+#pragma mark NSCopying
+
+- (instancetype)copyWithZone:(NSZone *)zone {
+	MTLJSONKeyPath *copy = [[self.class allocWithZone:zone] init];
+	copy.components = [self.components copy];
+	return copy;
+}
+
+#pragma mark NSObject
+
+- (NSString *)description {
+	return [NSString stringWithFormat:@"<%@: %p> %@", self.class, self, self.components];
+}
+
+- (NSUInteger)hash {
+	return [self.components hash];
+}
+
+- (BOOL)isEqual:(MTLJSONKeyPath *)object {
+	if (self == object) return YES;
+	if (![object isMemberOfClass:self.class]) return NO;
+	
+	return [self.components isEqualToArray:object.components];
+}
+
+@end

--- a/Mantle/Mantle.h
+++ b/Mantle/Mantle.h
@@ -15,6 +15,7 @@ FOUNDATION_EXPORT double MantleVersionNumber;
 FOUNDATION_EXPORT const unsigned char MantleVersionString[];
 
 #import <Mantle/MTLJSONAdapter.h>
+#import <Mantle/MTLJSONKeyPath.h>
 #import <Mantle/MTLModel.h>
 #import <Mantle/MTLModel+NSCoding.h>
 #import <Mantle/MTLValueTransformer.h>

--- a/Mantle/NSDictionary+MTLJSONKeyPath.h
+++ b/Mantle/NSDictionary+MTLJSONKeyPath.h
@@ -12,8 +12,9 @@
 
 /// Looks up the value of a key path in the receiver.
 ///
-/// JSONKeyPath - The key path that should be resolved. Every element along this
-///               key path needs to be an instance of NSDictionary for the
+/// JSONKeyPath - The key path that should be resolved. The key path must be
+///               an instance of NSString or MTLJSONKeyPath. Every element along
+///               this key path needs to be an instance of NSDictionary for the
 ///               resolving to be successful.
 /// success     - If not NULL, this will be set to a boolean indicating whether
 ///               the key path was resolved successfully.
@@ -22,6 +23,6 @@
 ///
 /// Returns the value for the key path which may be nil. Clients should inspect
 /// the success parameter to decide how to proceed with the result.
-- (id)mtl_valueForJSONKeyPath:(NSString *)JSONKeyPath success:(BOOL *)success error:(NSError **)error;
+- (id)mtl_valueForJSONKeyPath:(id)JSONKeyPath success:(BOOL *)success error:(NSError **)error;
 
 @end

--- a/Mantle/NSDictionary+MTLJSONKeyPath.m
+++ b/Mantle/NSDictionary+MTLJSONKeyPath.m
@@ -9,11 +9,18 @@
 #import "NSDictionary+MTLJSONKeyPath.h"
 
 #import "MTLJSONAdapter.h"
+#import "MTLJSONKeyPath.h"
 
 @implementation NSDictionary (MTLJSONKeyPath)
 
-- (id)mtl_valueForJSONKeyPath:(NSString *)JSONKeyPath success:(BOOL *)success error:(NSError **)error {
-	NSArray *components = [JSONKeyPath componentsSeparatedByString:@"."];
+- (id)mtl_valueForJSONKeyPath:(id)JSONKeyPath success:(BOOL *)success error:(NSError **)error {
+	NSArray *components;
+	
+	if ([JSONKeyPath isKindOfClass:[MTLJSONKeyPath class]]) {
+		components = ((MTLJSONKeyPath *)JSONKeyPath).components;
+	} else {
+		components = [(NSString *)JSONKeyPath componentsSeparatedByString:@"."];
+	}
 
 	id result = self;
 	for (NSString *component in components) {

--- a/MantleTests/MTLJSONAdapterSpec.m
+++ b/MantleTests/MTLJSONAdapterSpec.m
@@ -106,6 +106,34 @@ it(@"it should initialize properties with multiple key paths from JSON", ^{
 	expect(serializationError).to(beNil());
 });
 
+it(@"it should initialize properties with keys that contain dot literals from JSON", ^{
+	NSDictionary *values = @{
+							 @"literal.name": @"foo",
+							 @"literal.first_name": @"bar",
+							 @"literal.last_name": @"baz",
+							 @"nested": @{
+									 @"literal.name": @"qux",
+									 @"literal.first_name": @"grault",
+									 @"literal.last_name": @"xyzzy"
+									 }
+							 };
+	
+	NSError *error = nil;
+	MTLDotLiteralKeyPathModel *model = [MTLJSONAdapter modelOfClass:MTLDotLiteralKeyPathModel.class fromJSONDictionary:values error:&error];
+	expect(model).notTo(beNil());
+	expect(error).to(beNil());
+	
+	expect(model.name).to(equal(@"foo"));
+	expect(model.nestedName).to(equal(@"qux"));
+	
+	expect(model.fullName).to(equal(@"bar baz"));
+	expect(model.nestedFullName).to(equal(@"grault xyzzy"));
+	
+	__block NSError *serializationError;
+	expect([MTLJSONAdapter JSONDictionaryFromModel:model error:&serializationError]).to(equal(values));
+	expect(serializationError).to(beNil());
+});
+
 it(@"should return nil and error with an invalid key path from JSON",^{
 	NSDictionary *values = @{
 		@"username": @"foo",

--- a/MantleTests/MTLTestModel.h
+++ b/MantleTests/MTLTestModel.h
@@ -170,6 +170,25 @@ extern const NSInteger MTLTestModelNameMissing;
 
 @end
 
+@interface MTLDotLiteralKeyPathModel : MTLModel <MTLJSONSerializing>
+
+// This property is associated with the "literal.name" key in JSON.
+@property (readonly, nonatomic, assign) NSString *name;
+
+// This property is associated with the "'nested'.'literal.name'" key path
+// in JSON.
+@property (readonly, nonatomic, assign) NSString *nestedName;
+
+// This property is associated with the "literal.first_name" and
+// "literal.last_name" keys in JSON.
+@property (readonly, nonatomic, assign) NSString *fullName;
+
+// This property is associated with the "'nested'.'literal.first_name'" and
+// "'nested'.'literal.last_name'" key paths in JSON.
+@property (readonly, nonatomic, assign) NSString *nestedFullName;
+
+@end
+
 @interface MTLClassClusterModel : MTLModel <MTLJSONSerializing>
 
 @property (readonly, nonatomic, copy) NSString *flavor;

--- a/MantleTests/MTLTestModel.m
+++ b/MantleTests/MTLTestModel.m
@@ -10,6 +10,7 @@
 
 #import "MTLTestModel.h"
 #import "NSDictionary+MTLMappingAdditions.h"
+#import "MTLJSONKeyPath.h"
 
 NSString * const MTLTestModelErrorDomain = @"MTLTestModelErrorDomain";
 const NSInteger MTLTestModelNameTooLong = 1;
@@ -459,6 +460,49 @@ static NSUInteger modelVersion = 1;
 			};
 		}];
 }
+@end
+
+@implementation MTLDotLiteralKeyPathModel
+
++ (NSDictionary *)JSONKeyPathsByPropertyKey {
+	return @{
+			 @"name": MTLKeyPath(@"literal.name"),
+			 @"nestedName": MTLKeyPath(@"nested", @"literal.name"),
+			 @"fullName": @[ MTLKeyPath(@"literal.first_name"), MTLKeyPath(@"literal.last_name") ],
+			 @"nestedFullName": @[ MTLKeyPath(@"nested", @"literal.first_name"), MTLKeyPath(@"nested", @"literal.last_name") ]
+			 };
+}
+
++ (NSValueTransformer *)fullNameJSONTransformer {
+	return [MTLValueTransformer transformerUsingForwardBlock:^id(id value, BOOL *success, NSError *__autoreleasing *error) {
+		NSString *firstName = value[MTLKeyPath(@"literal.first_name")];
+		NSString *lastName = value[MTLKeyPath(@"literal.last_name")];
+		return [@[firstName, lastName] componentsJoinedByString:@" "];
+	} reverseBlock:^(NSString *value, BOOL *success, NSError **error) {
+		NSArray *nameComponents = [value componentsSeparatedByString:@" "];
+		
+		return @{
+				 MTLKeyPath(@"literal.first_name"): nameComponents[0],
+				 MTLKeyPath(@"literal.last_name"): nameComponents[1]
+				 };
+	}];
+}
+
++ (NSValueTransformer *)nestedFullNameJSONTransformer {
+	return [MTLValueTransformer transformerUsingForwardBlock:^id(id value, BOOL *success, NSError *__autoreleasing *error) {
+		NSString *firstName = value[MTLKeyPath(@"nested", @"literal.first_name")];
+		NSString *lastName = value[MTLKeyPath(@"nested", @"literal.last_name")];
+		return [@[firstName, lastName] componentsJoinedByString:@" "];
+	} reverseBlock:^(NSString *value, BOOL *success, NSError **error) {
+		NSArray *nameComponents = [value componentsSeparatedByString:@" "];
+		
+		return @{
+				 MTLKeyPath(@"nested", @"literal.first_name"): nameComponents[0],
+				 MTLKeyPath(@"nested", @"literal.last_name"): nameComponents[1]
+				 };
+	}];
+}
+
 @end
 
 @implementation MTLClassClusterModel : MTLModel


### PR DESCRIPTION
I've been happily using Mantle for years and I finally need to support JSON keys with dots. It looks like this feature has been discussed and implemented before, but has never been merged into the main project. 

I'm hoping we can get this merged into the next version of Mantle. Please let me know what you think and if there is anything I can do to help with this process.

Thanks,
Will

# Support JSON Keys with Dots

* Fixes: #508
* Fixes: #769
* Alternative: #782


## Introduction
This adds support for JSON keys that contain dot (`.`) literals. It [promotes JSON key paths to a type](https://github.com/Mantle/Mantle/issues/508#issuecomment-97065244) (`MTLJSONKeyPath`) that can be composed of arbitrary strings.


## Motivation

Mantle currently represents a JSON key path as a string. The string may contain dot-separated keys that specify nodes in a JSON object.

The `MTLJSONSerializing` protocol uses JSON key paths to specify how to map object property keys to key paths in a JSON object:

```json
{  
    "POI":{  
        "name":"Yosemite"
    },
    "starred":true
}
```

```objc
+ (NSDictionary *)JSONKeyPathsByPropertyKey {
    return @{
             @"name": @"POI.name",
             @"starred": @"starred",
             };
}
```

This will map the object's `name` property to `JSONDictionary[@"POI"][@"name"]` and `starred` property to `JSONDictionary[@"starred"]`.

### Complications with Dots in JSON Keys

The dot syntax for JSON key path strings is convenient for "dot walking" to a node in a JSON object. However, the current implementation makes it impossible to specify a JSON key path to a JSON key that contains a dot (`.`) literal:

```json
{  
    "com.github":{  
        "user":{  
            "username":"lattner"
        }
    }
}
```

## Detailed Design

Promoting JSON key paths to a type allows key paths to be composed of arbitrary string `components`.

### `MTLJSONKeyPath`

```objc
/// A class used to represent a JSON key path by discrete key components.
@interface MTLJSONKeyPath : NSObject <NSCopying>

/// An array of JSON keys that represent a JSON key path.
///
/// This property will never be nil.
@property (nonatomic, strong, readonly) NSArray<NSString *> *components;

/// Initializes the receiver with the given JSON key components.
///
/// components - The array of JSON keys that represent a JSON key path.
///              This argument must not be nil.
///
/// Returns an initialized JSON Key path.
- (instancetype)initWithComponents:(NSArray<NSString *> *)components;

@end

/// MTLKeyPath is a macro that initializes and returns a MTLJSONKeyPath
/// object with the given JSON key components.
#define MTLKeyPath(...) \
	[[MTLJSONKeyPath alloc] initWithComponents:@[__VA_ARGS__]]

```

### Example Usage

```json
{  
    "com.github":{  
        "user":{  
            "username":"lattner"
        }
    },
    "project":{  
        "language":"Swift"
    }
}
```

```objc
+ (NSDictionary *)JSONKeyPathsByPropertyKey {
    return @{
             @"username": MTLKeyPath(@"com.github", @"user", @"username"),
             @"language": @"project.language"
             };
}
```

This will map the object's `username` property to `JSONDictionary[@"com.github"][@"user"][@"username"]` and `language` property to `JSONDictionary[@"project"][@"language"]`.


## Impact on Existing Code

This proposal is additive and fully backwards compatible. It will not require changes to existing code.


## Alternatives Considered

Use an escape sequence for allowing dot (`.`) literals in JSON key path strings. This has been suggested and implemented in #782 and #656. This introduces potentially breaking changes for JSON keys that contain backslash (`\`) literals. It also [requires double escaping](https://github.com/Mantle/Mantle/issues/508#issuecomment-97064299) (`\\`) since Xcode already treats `\` as an escape sequence.
