### PR TITLE
Fix mapping nil transformer output back to NSNull

### DIFF
--- a/Mantle/MTLJSONAdapter.m
+++ b/Mantle/MTLJSONAdapter.m
@@ -206,7 +206,7 @@ NSString * const MTLJSONAdapterThrownExceptionErrorKey = @"MTLJSONAdapterThrownE
 			if ([transformer respondsToSelector:@selector(reverseTransformedValue:success:error:)]) {
 				id<MTLTransformerErrorHandling> errorHandlingTransformer = (id)transformer;
 
-				value = [errorHandlingTransformer reverseTransformedValue:value success:&success error:&tmpError];
+				value = [errorHandlingTransformer reverseTransformedValue:value success:&success error:&tmpError] ?: NSNull.null;
 
 				if (!success) {
 					*stop = YES;


### PR DESCRIPTION
Bug: if a transformer encodes a value to `nil`, it's converted to a missing value, not to a `null` value.

Example. My model has an integer value. In case of equality to `INVALID_VALUE` constant, it should be encoded as `null`. So I implement the transformer as follows:

```Objective-C
return [MTLValueTransformer transformerUsingForwardBlock:^id(NSNumber *num, BOOL *success, NSError *__autoreleasing *error) {
    return num?: @(INVALID_VALUE);
} reverseBlock:^id(NSNumber *num, BOOL *success, NSError *__autoreleasing *error) {
    return (num.intValue == INVALID_VALUE)? nil: num;
}];
```

I convert a structure with an invalid value in a following manner: model → JSON → model. And the value is transformed as `INVALID_VALUE` → absent value → 0 (not assigned).

The reason is a mistake in MTLJSONAdapter. As [stated in comments](https://github.com/Mantle/Mantle/blob/2.1.0/Mantle/MTLJSONAdapter.m#L202-L203), it maps NSNull → nil to use the transformer, and then back after the transformer. But the reverse mapping isn't performed in this specific case.