### PR TITLE
get value by keypath not by `objectForKey` since we want to get the value from keypath

### DIFF
--- a/Mantle/MTLJSONAdapter.m
+++ b/Mantle/MTLJSONAdapter.m
@@ -241,8 +241,9 @@ NSString * const MTLJSONAdapterThrownExceptionErrorKey = @"MTLJSONAdapterThrownE
 		if ([JSONKeyPaths isKindOfClass:NSArray.class]) {
 			for (NSString *JSONKeyPath in JSONKeyPaths) {
 				createComponents(JSONDictionary, JSONKeyPath);
-
-				[JSONDictionary setValue:value[JSONKeyPath] forKeyPath:JSONKeyPath];
+				
+				id tmpValue = [value mtl_valueForJSONKeyPath:JSONKeyPath success:&success error:&tmpError];
+				[JSONDictionary setValue:tmpValue forKeyPath:JSONKeyPath];
 			}
 		}
 	}];


### PR DESCRIPTION
Get value by keypath(`mtl_valueForJSONKeyPath:success:error:`) not by `objectForKey` since we want to get the value from keypath.