### PR TITLE
Omit processing one, if all JSON keys of a property do not exist

### DIFF
--- a/Mantle/MTLJSONAdapter.m
+++ b/Mantle/MTLJSONAdapter.m
@@ -302,7 +302,7 @@ NSString * const MTLJSONAdapterThrownExceptionErrorKey = @"MTLJSONAdapterThrownE
 				if (value != nil) dictionary[keyPath] = value;
 			}
 
-			value = dictionary;
+			value = dictionary.count > 0 ? dictionary : nil;
 		} else {
 			BOOL success = NO;
 			value = [JSONDictionary mtl_valueForJSONKeyPath:JSONKeyPaths success:&success error:error];

--- a/MantleTests/MTLJSONAdapterSpec.m
+++ b/MantleTests/MTLJSONAdapterSpec.m
@@ -87,7 +87,9 @@ it(@"it should initialize properties with multiple key paths from JSON", ^{
 		@"nested": @{
 			@"location": @12,
 			@"length": @34
-		}
+		},
+		@"userName": @"name",
+		@"userAge": @20,
 	};
 
 	NSError *error = nil;
@@ -101,8 +103,40 @@ it(@"it should initialize properties with multiple key paths from JSON", ^{
 	expect(@(model.nestedRange.location)).to(equal(@12));
 	expect(@(model.nestedRange.length)).to(equal(@34));
 
+	expect(model.user.name).to(equal(@"name"));
+	expect(@(model.user.age)).to(equal(@20));
+
 	__block NSError *serializationError;
 	expect([MTLJSONAdapter JSONDictionaryFromModel:model error:&serializationError]).to(equal(values));
+	expect(serializationError).to(beNil());
+});
+
+it(@"should omit processing one, if all JSON keys of a property do not exist", ^{
+	NSDictionary *values = @{};
+
+	NSError *error = nil;
+	MTLMultiKeypathModel *model = [MTLJSONAdapter modelOfClass:MTLMultiKeypathModel.class fromJSONDictionary:values error:&error];
+	expect(model).notTo(beNil());
+	expect(error).to(beNil());
+
+	expect(@(model.range.location)).to(equal(@0));
+	expect(@(model.range.length)).to(equal(@0));
+
+	expect(@(model.nestedRange.location)).to(equal(@0));
+	expect(@(model.nestedRange.length)).to(equal(@0));
+
+	expect(model.user).to(beNil());
+
+	NSDictionary *expectedValues = @{
+		@"location": @0,
+		@"length": @0,
+		@"nested": @{
+			@"location": @0,
+			@"length": @0
+		},
+	};
+	__block NSError *serializationError;
+	expect([MTLJSONAdapter JSONDictionaryFromModel:model error:&serializationError]).to(equal(expectedValues));
 	expect(serializationError).to(beNil());
 });
 

--- a/MantleTests/MTLTestModel.h
+++ b/MantleTests/MTLTestModel.h
@@ -159,6 +159,13 @@ extern const NSInteger MTLTestModelNameMissing;
 
 @end
 
+@interface MTLMultiKeypathClassModel : MTLModel <MTLJSONSerializing>
+
+@property (readonly, nonatomic, copy) NSString* name;
+@property (readonly, nonatomic, assign) NSUInteger age;
+
+@end
+
 @interface MTLMultiKeypathModel : MTLModel <MTLJSONSerializing>
 
 // This property is associated with the "location" and "length" keys in JSON.
@@ -167,6 +174,8 @@ extern const NSInteger MTLTestModelNameMissing;
 // This property is associated with the "nested.location" and "nested.length"
 // keys in JSON.
 @property (readonly, nonatomic, assign) NSRange nestedRange;
+
+@property (readonly, nonatomic, strong) MTLMultiKeypathClassModel* user;
 
 @end
 

--- a/MantleTests/MTLTestModel.m
+++ b/MantleTests/MTLTestModel.m
@@ -415,6 +415,17 @@ static NSUInteger modelVersion = 1;
 
 @end
 
+@implementation MTLMultiKeypathClassModel
+
++ (NSDictionary *)JSONKeyPathsByPropertyKey {
+	return @{
+		@"name" : @"userName",
+		@"age" : @"userAge",
+	};
+}
+
+@end
+
 @implementation MTLMultiKeypathModel
 
 #pragma mark MTLJSONSerializing
@@ -422,7 +433,8 @@ static NSUInteger modelVersion = 1;
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
 	return @{
 		@"range": @[ @"location", @"length" ],
-		@"nestedRange": @[ @"nested.location", @"nested.length" ]
+		@"nestedRange": @[ @"nested.location", @"nested.length" ],
+		@"user": [[MTLMultiKeypathClassModel JSONKeyPathsByPropertyKey] allValues],
 	};
 }
 


### PR DESCRIPTION
```objc
@interface Child : MTLModel <MTLJSONSerializing>
@property (nonatomic, nonnull, copy) NSString* a; // <-- nonnull !!
@property (nonatomic, nonnull, copy) NSString* b;
@end

@implementation Child

+ (NSDictionary*)JSONKeyPathsByPropertyKey
{
    return {@"a" : @"a", @"b": @"b"};
}

- (BOOL)validate:(NSError**)error
{
    return self.a != nil && self.b != nil;
}

@end

@interface Parent : MTLModel <MTLJSONSerializing>
@property (nonatomic, nullable, strong) Child* child; // <-- nullable !!
@end

@implementation Parent
+ (NSDictionary*)JSONKeyPathsByPropertyKey
{
    return {@"child" : @[@"a", @"b"]};
}
@end
```

Now, we can not use multi key path for nullable property of MTLModel.
Because, MTLJSONAdapter try to convert the MTLModel from empty dictionary, but the MTLModel validation will fail.

This pull request fixes this.
