### PR TITLE
Carthage + Xcode 9 compatibility

### DIFF
--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,3 +1,3 @@
 github "jspahrsummers/xcconfigs" "1ef9763"
 github "Quick/Quick" ~> 1.1.0
-github "Quick/Nimble" ~> 7.0
+github "Quick/Nimble" ~> 7.0.1


### PR DESCRIPTION
Updated `Quick/Nimble` version to `7.0.1` for Xcode 9 support.