### PR TITLE
Change imports in Mantle.h to prevent Swift AST errors

### DIFF
--- a/Mantle.podspec.json
+++ b/Mantle.podspec.json
@@ -1,0 +1,30 @@
+{
+  "name": "Mantle",
+  "version": "2.1.0",
+  "summary": "Model framework for Cocoa and Cocoa Touch.",
+  "homepage": "https://github.com/Mantle/Mantle",
+  "license": "MIT",
+  "authors": {
+    "Github": "support@github.com"
+  },
+  "source": {
+    "git": "https://github.com/ChatSecure/Mantle.git",
+    "branch": "2.1.0_headerfix"
+  },
+  "platforms": {
+    "ios": "5.0",
+    "osx": "10.7",
+    "watchos": "2.0",
+    "tvos": "9.0"
+  },
+  "requires_arc": true,
+  "frameworks": "Foundation",
+  "source_files": "Mantle",
+  "subspecs": [
+    {
+      "name": "extobjc",
+      "source_files": "Mantle/extobjc",
+      "private_header_files": "Mantle/extobjc/*.h"
+    }
+  ]
+}

--- a/Mantle/Mantle.h
+++ b/Mantle/Mantle.h
@@ -14,14 +14,14 @@ FOUNDATION_EXPORT double MantleVersionNumber;
 //! Project version string for Mantle.
 FOUNDATION_EXPORT const unsigned char MantleVersionString[];
 
-#import <Mantle/MTLJSONAdapter.h>
-#import <Mantle/MTLModel.h>
-#import <Mantle/MTLModel+NSCoding.h>
-#import <Mantle/MTLValueTransformer.h>
-#import <Mantle/MTLTransformerErrorHandling.h>
-#import <Mantle/NSArray+MTLManipulationAdditions.h>
-#import <Mantle/NSDictionary+MTLManipulationAdditions.h>
-#import <Mantle/NSDictionary+MTLMappingAdditions.h>
-#import <Mantle/NSObject+MTLComparisonAdditions.h>
-#import <Mantle/NSValueTransformer+MTLInversionAdditions.h>
-#import <Mantle/NSValueTransformer+MTLPredefinedTransformerAdditions.h>
+#import "MTLJSONAdapter.h"
+#import "MTLModel.h"
+#import "MTLModel+NSCoding.h"
+#import "MTLValueTransformer.h"
+#import "MTLTransformerErrorHandling.h"
+#import "NSArray+MTLManipulationAdditions.h"
+#import "NSDictionary+MTLManipulationAdditions.h"
+#import "NSDictionary+MTLMappingAdditions.h"
+#import "NSObject+MTLComparisonAdditions.h"
+#import "NSValueTransformer+MTLInversionAdditions.h"
+#import "NSValueTransformer+MTLPredefinedTransformerAdditions.h"


### PR DESCRIPTION
I don't know if this affects anyone else, but I still need to remove the angled includes in Mantle.h to prevent Swift AST debugger errors in a mixed Obj-C/Swift framework target. I've heard differing reports on which way is "correct", but the angled includes definitely give me more issues for whatever reason.