### PR TITLE
Block Definition Fix for mtl_cleanupBlock_t

### DIFF
--- a/Mantle/extobjc/EXTScope.h
+++ b/Mantle/extobjc/EXTScope.h
@@ -88,7 +88,7 @@
     _Pragma("clang diagnostic pop")
 
 /*** implementation details follow ***/
-typedef void (^mtl_cleanupBlock_t)();
+typedef void (^mtl_cleanupBlock_t)(void);
 
 void mtl_executeCleanupBlock (__strong mtl_cleanupBlock_t *block);
 


### PR DESCRIPTION
(This is my first GitHub pull request!  Please let me know if I have done anything incorrectly.)
This is to fix the xcode warning: "This block declaration is not a prototype".
![screen shot 2018-04-28 at 9 47 52 am](https://user-images.githubusercontent.com/26758270/39407503-050ad582-4b95-11e8-8b37-0716cfede16c.png)
