### PR TITLE
Fixed static analyzer warning about leaking attributes

### DIFF
--- a/Mantle/extobjc/EXTRuntimeExtensions.m
+++ b/Mantle/extobjc/EXTRuntimeExtensions.m
@@ -55,7 +55,7 @@ mtl_propertyAttributes *mtl_copyPropertyAttributes (objc_property_t property) {
 
         if (!next) {
             fprintf(stderr, "ERROR: Could not read class name in attribute string \"%s\" for property %s\n", attrString, property_getName(property));
-            return NULL;
+			goto errorOut;
         }
 
         if (className != next) {


### PR DESCRIPTION
Fixes a static analyzer warning that showed up in Xcode 10.