### PR TITLE
Make Cocoapods Support Official

### DIFF
--- a/.github/workflows/cocoapods-publish.yml
+++ b/.github/workflows/cocoapods-publish.yml
@@ -1,0 +1,34 @@
+name: cocoapods-publish
+
+on:
+  push:
+    tags:
+    - '*'
+
+jobs:
+  build:
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Updating submodules
+      run: git submodule update --init --recursive
+    - name: Get the version from tag
+      id: get_version
+      run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+    - name: Publish to Cocoapods
+      env:
+        COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
+        MANTLE_VERSION: ${{ steps.get_version.outputs.VERSION }}
+      run: |
+        mkdir -p tmp
+
+        # Modify the podspec with the version & tag and run lint on it
+        jq --arg VERSION "$MANTLE_VERSION" '. | .version |= $VERSION | .source.tag |= $VERSION' Mantle.podspec.json > tmp/Mantle.podspec.json
+        pod spec lint tmp/Mantle.podspec.json --skip-import-validation --allow-warnings
+
+        # Print out the podspec we'll submit
+        cat tmp/Mantle.podspec.json
+
+        # Time to ship!
+        pod trunk push tmp/Mantle.podspec.json --skip-import-validation --allow-warnings

--- a/Mantle.podspec.json
+++ b/Mantle.podspec.json
@@ -1,0 +1,30 @@
+{
+  "name": "Mantle",
+  "summary": "Model framework for Cocoa and Cocoa Touch.",
+  "homepage": "https://github.com/Mantle/Mantle",
+  "license": "MIT",
+  "authors": {
+    "Robert Böhnke": "robb@robb.is",
+    "David Caunt": "dcaunt@gmail.com",
+    "Jan Gorman": "gorman.jan@gmail.com"
+  },
+  "source": {
+    "git": "https://github.com/Mantle/Mantle.git"
+  },
+  "platforms": {
+    "ios": "5.0",
+    "osx": "10.7",
+    "watchos": "2.0",
+    "tvos": "9.0"
+  },
+  "requires_arc": true,
+  "frameworks": "Foundation",
+  "source_files": "Mantle",
+  "subspecs": [
+    {
+      "name": "extobjc",
+      "source_files": "Mantle/extobjc",
+      "private_header_files": "Mantle/extobjc/*.h"
+    }
+  ]
+}


### PR DESCRIPTION
**Description**

This fixes #831 by bringing in the community-created unofficial Cocoapods spec into the Mantle repository.  It has been updated slightly to reflect the correct URLs & authors (as denoted by `pod trunk info Mantle`).  Version & source.tag fields have been purposefully removed as those will now be provided by the auto-deploy GitHub Action.

The cocoapods-publish GitHub action is based off one done in [Alloy](https://github.com/s1ddok/Alloy) that is described in detail [here](https://medium.com/swlh/automated-cocoapod-releases-with-github-actions-8526dd4535c7).  Major differences to their setup is I've set up to trigger this one on any tag push.  Given past tags have all used the semantic versioning, the tag's name is pulled & used to fill in the version & source.tag fields of the podspec.  This is done so we never have a podspec whose version is out of sync with the official release/tag.  We then run a lint, record the final podspec we sent into the GitHub Actions log for debugging purposes, & then submit the podspec to Cocoapods Trunk service.

An example run (but with final step of submitting to Cocoapods disabled) can be found here: https://github.com/abotkin/Mantle/runs/409136943?check_suite_focus=true

**Actions Needed**

We need to retrieve a Cocoapods Trunk token & put it in the GitHub Secrets of the project (found in Settings).  This can only be performed by one of the existing Cocoapod Trunk registered owners (found by `pod trunk info Mantle`) below using that email address on record:

      - Robert Böhnke <robb@robb.is>
      - David Caunt <dcaunt@gmail.com>
      - Jan Gorman <gorman.jan@gmail.com>

A registered owner (@robb @dcaunt @JanGorman) with the Cocoapods Trunk service needs to retrieve the Cocoapods Trunk token thusly:

1. Register a Cocoapods Trunk session using your owner email `pod trunk register email@example.com 'FirstName LastName' --description='cocoapods-publish GitHub Action'`
2. An email will be sent to the address given. Click the link to activate the session.
3. Retrieve the created token via `pod trunk me --verbose`

You'll see output like this:

```
opening connection to trunk.cocoapods.org:443...
opened
starting SSL for trunk.cocoapods.org:443...
SSL established, protocol: TLSv1.2, cipher: ECDHE-RSA-AES128-GCM-SHA256
<- "GET /api/v1/sessions HTTP/1.1\r\nContent-Type: application/json; charset=utf-8\r\nAccept: application/json; charset=utf-8\r\nUser-Agent: CocoaPods/1.7.4\r\nAuthorization: Token XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nHost: trunk.cocoapods.org\r\n\r\n"
-> "HTTP/1.1 200 OK\r\n"
-> "Date: Sun, 22 Sep 2019 05:11:46 GMT\r\n"
-> "Connection: keep-alive\r\n"
-> "Strict-Transport-Security: max-age=31536000\r\n"
-> "Content-Type: application/json\r\n"
-> "Content-Length: 1491\r\n"
-> "X-Content-Type-Options: nosniff\r\n"
-> "Server: thin 1.6.2 codename Doc Brown\r\n"
-> "Via: 1.1 vegur\r\n"
-> "\r\n"
```

`XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX` in the Authorization Token is the Cocoapods Trunk Token.  This should never be published publicly.

4.  Go the Mantle GitHub page -> Settings -> Secrets & add the token as the secret named `COCOAPODS_TRUNK_TOKEN`

These tokens expire every 5 months or so.  It would be ideal to move these instructions into a documentation file in the repo.  @robb Would you like me to add these instructions into a new COCOAPODS.md file?

The only other thing once that is all set-up is to pick the new commit we want to tag with a new version to get some of those priorly addressed warnings fixed in master (#831) in folks' Cocoapods.