### PR TITLE
Update the Cocoapods spec & README to match the deployment targets claimed in the xcworkspace

### DIFF
--- a/Mantle.podspec.json
+++ b/Mantle.podspec.json
@@ -12,8 +12,8 @@
     "git": "https://github.com/Mantle/Mantle.git"
   },
   "platforms": {
-    "ios": "5.0",
-    "osx": "10.7",
+    "ios": "8.0",
+    "osx": "10.10",
     "watchos": "2.0",
     "tvos": "9.0"
   },

--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
-# Mantle [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
+# Mantle
 
-Mantle makes it easy to write a simple model layer for your Cocoa or Cocoa Touch
-application.
+[![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
+[![CocoaPods Compatible](https://img.shields.io/cocoapods/v/Mantle.svg)](https://img.shields.io/cocoapods/v/Mantle.svg)
+[![Platform](https://img.shields.io/cocoapods/p/Mantle.svg?style=flat)](http://cocoadocs.org/docsets/Mantle)
+
+Mantle makes it easy to write a simple model layer for your Cocoa or Cocoa Touch application.
 
 ## The Typical Model Object
 
@@ -472,7 +475,12 @@ in memory at once, Core Data may be a better choice.
 
 ## System Requirements
 
-Mantle supports OS X 10.9+ and iOS 8.0+.
+Mantle supports the following platform deployment targets:
+
+* macOS 10.10+
+* iOS 8.0+
+* tvOS 9.0+
+* watchOS 2.0+
 
 ## Importing Mantle
 


### PR DESCRIPTION
This fixes #849 where [Twitter's taichino pointed out](https://twitter.com/taichino/status/1051905895142187008) that the deployment targets claimed in the Mantle podspec do not align with what's claimed in the Xcode project. The Cocoapods spec is updated to reflect that iOS requires iOS 8 or above and macOS requires macOS 10.10 or above.  The README.md was also still claiming macOS 10.9 support, so that has been updated as well.

Some additional modifications to the README were also made to highlight are Cocoapods compatibility & platform support.