### PR TITLE
Swift Package Manager Support

### DIFF
--- a/Mantle/MTLJSONAdapter.m
+++ b/Mantle/MTLJSONAdapter.m
@@ -10,8 +10,8 @@
 
 #import "NSDictionary+MTLJSONKeyPath.h"
 
-#import <Mantle/EXTRuntimeExtensions.h>
-#import <Mantle/EXTScope.h>
+#import "EXTRuntimeExtensions.h"
+#import "EXTScope.h"
 #import "MTLJSONAdapter.h"
 #import "MTLModel.h"
 #import "MTLTransformerErrorHandling.h"

--- a/Mantle/MTLModel+NSCoding.m
+++ b/Mantle/MTLModel+NSCoding.m
@@ -7,8 +7,8 @@
 //
 
 #import "MTLModel+NSCoding.h"
-#import <Mantle/EXTRuntimeExtensions.h>
-#import <Mantle/EXTScope.h>
+#import "EXTRuntimeExtensions.h"
+#import "EXTScope.h"
 #import "MTLReflection.h"
 
 // Used in archives to store the modelVersion of the archived instance.

--- a/Mantle/MTLModel.m
+++ b/Mantle/MTLModel.m
@@ -8,8 +8,8 @@
 
 #import "NSError+MTLModelException.h"
 #import "MTLModel.h"
-#import <Mantle/EXTRuntimeExtensions.h>
-#import <Mantle/EXTScope.h>
+#import "EXTRuntimeExtensions.h"
+#import "EXTScope.h"
 #import "MTLReflection.h"
 #import <objc/runtime.h>
 

--- a/Mantle/Mantle.h
+++ b/Mantle/Mantle.h
@@ -16,7 +16,9 @@ FOUNDATION_EXPORT const unsigned char MantleVersionString[];
 
 // These imports should not be visible to SPM & SPM doesn't seem to have the target "exclude" apply to headers
 // & publicHeadersPath is a single string, so can't just list all the headers we want unless we move them into a folder
-#if MANTLE_SPM
+#if SWIFT_PACKAGE
+    // No headers
+#else
 
 #import <Mantle/MTLJSONAdapter.h>
 #import <Mantle/MTLModel.h>

--- a/Mantle/Mantle.h
+++ b/Mantle/Mantle.h
@@ -14,6 +14,10 @@ FOUNDATION_EXPORT double MantleVersionNumber;
 //! Project version string for Mantle.
 FOUNDATION_EXPORT const unsigned char MantleVersionString[];
 
+// These imports should not be visible to SPM & SPM doesn't seem to have the target "exclude" apply to headers
+// & publicHeadersPath is a single string, so can't just list all the headers we want unless we move them into a folder
+#if SWIFT_PACKAGE
+
 #import <Mantle/MTLJSONAdapter.h>
 #import <Mantle/MTLModel.h>
 #import <Mantle/MTLModel+NSCoding.h>
@@ -25,3 +29,5 @@ FOUNDATION_EXPORT const unsigned char MantleVersionString[];
 #import <Mantle/NSObject+MTLComparisonAdditions.h>
 #import <Mantle/NSValueTransformer+MTLInversionAdditions.h>
 #import <Mantle/NSValueTransformer+MTLPredefinedTransformerAdditions.h>
+
+#endif /* SWIFT_PACKAGE */

--- a/Mantle/Mantle.h
+++ b/Mantle/Mantle.h
@@ -16,7 +16,7 @@ FOUNDATION_EXPORT const unsigned char MantleVersionString[];
 
 // These imports should not be visible to SPM & SPM doesn't seem to have the target "exclude" apply to headers
 // & publicHeadersPath is a single string, so can't just list all the headers we want unless we move them into a folder
-#if SWIFT_PACKAGE
+#if MANTLE_SPM
 
 #import <Mantle/MTLJSONAdapter.h>
 #import <Mantle/MTLModel.h>
@@ -30,4 +30,4 @@ FOUNDATION_EXPORT const unsigned char MantleVersionString[];
 #import <Mantle/NSValueTransformer+MTLInversionAdditions.h>
 #import <Mantle/NSValueTransformer+MTLPredefinedTransformerAdditions.h>
 
-#endif /* SWIFT_PACKAGE */
+#endif /* MANTLE_SPM */

--- a/Package.swift
+++ b/Package.swift
@@ -28,10 +28,7 @@ let package = Package(
             exclude: [
                 "extobjc",
             ],
-            publicHeadersPath: ".",
-            cSettings: [
-                .define("MANTLE_SPM", to: "1"),  // Prevent framework import headers
-        ]),
+            publicHeadersPath: "."),
         .target(
             name: "extobjc",
             dependencies: [],

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,46 @@
+// swift-tools-version:5.1
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "Mantle",
+    platforms: [
+        .macOS(.v10_10),
+        .iOS(.v8),
+        .tvOS(.v9),
+        .watchOS(.v2)
+    ],
+    products: [
+        .library(
+            name: "Mantle",
+            targets: ["Mantle"]),
+    ],
+    dependencies: [
+//        .package(url: "https://github.com/Quick/Nimble.git", from: "8.0.5"),
+//        .package(url: "https://github.com/Quick/Quick.git", from: "2.2.0"),
+    ],
+    targets: [
+        .target(
+            name: "Mantle",
+            dependencies: ["extobjc"],
+            path: "Mantle",
+            exclude: [
+                "extobjc",
+            ],
+            publicHeadersPath: ".",
+            cSettings: [
+                .define("SWIFT_PACKAGE", to: "1"),  // Prevent framework import headers
+        ]),
+        .target(
+            name: "extobjc",
+            dependencies: [],
+            path: "Mantle/extobjc",
+            publicHeadersPath: ".")
+// Note: this is commented out as SPM doesn't currently support ObjC/Swift mixed targets
+//        .testTarget(
+//            name: "MantleTests",
+//            dependencies: ["Mantle", "Nimble", "Quick"],
+//            path: "MantleTests"),
+    ]
+)

--- a/Package.swift
+++ b/Package.swift
@@ -30,7 +30,7 @@ let package = Package(
             ],
             publicHeadersPath: ".",
             cSettings: [
-                .define("SWIFT_PACKAGE", to: "1"),  // Prevent framework import headers
+                .define("MANTLE_SPM", to: "1"),  // Prevent framework import headers
         ]),
         .target(
             name: "extobjc",


### PR DESCRIPTION
This fixes #847 by adding in a Package.swift definition for Mantle.  An example project that depends on this SPM support to do an example serialize/deserialize can be found [here](https://github.com/abotkin/MantleSwiftExample).  For anyone who'd like to try the experiment and report results, add the following as your dependency to your Package.swift

```
.package(url: "https://github.com/Mantle/Mantle.git", .revision("10514f54b3b42f76cd87fceca64658ae5cf565aa"))
```

I'm using MANTLE_SPM to prevent imports that are problematic when building for SPM.  Also switched a few import statements in the implementation files.  I haven't updated the README as unsure if we want to encourage using Mantle in Swift since most folks would be better off using Swift Codable.

It would be nice to get a few folks to run either the example project or try adding the revision to their own SPM project and confirm that this set-up works well.  @luismmejiasb, any chance you could give it a try?