### PR TITLE
Add support for JSON keys with dots with MTLJSONKeyPath

### DIFF
--- a/Mantle.xcodeproj/project.pbxproj
+++ b/Mantle.xcodeproj/project.pbxproj
@@ -41,11 +41,26 @@
 		88080C18160A706900CCABF2 /* NSArray+MTLManipulationAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 88080C16160A706900CCABF2 /* NSArray+MTLManipulationAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		88080C19160A706900CCABF2 /* NSArray+MTLManipulationAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 88080C17160A706900CCABF2 /* NSArray+MTLManipulationAdditions.m */; };
 		88080C1D160A719D00CCABF2 /* MTLArrayManipulationSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 88080C1C160A719D00CCABF2 /* MTLArrayManipulationSpec.m */; };
+		BE298E4A1E8EF4F6003A9848 /* MTLJSONKeyPath.h in Headers */ = {isa = PBXBuildFile; fileRef = BE298E481E8EF4F6003A9848 /* MTLJSONKeyPath.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BE298E4B1E8EF4F6003A9848 /* MTLJSONKeyPath.m in Sources */ = {isa = PBXBuildFile; fileRef = BE298E491E8EF4F6003A9848 /* MTLJSONKeyPath.m */; };
+		BE788B2F1E8F358100727A91 /* NSDictionary+MTLJSONKeyPath.h in Headers */ = {isa = PBXBuildFile; fileRef = 54EDCD0818D9B34F005796FC /* NSDictionary+MTLJSONKeyPath.h */; };
+		BE788B301E8F358200727A91 /* NSDictionary+MTLJSONKeyPath.h in Headers */ = {isa = PBXBuildFile; fileRef = 54EDCD0818D9B34F005796FC /* NSDictionary+MTLJSONKeyPath.h */; };
+		BE788B311E8F358300727A91 /* NSDictionary+MTLJSONKeyPath.h in Headers */ = {isa = PBXBuildFile; fileRef = 54EDCD0818D9B34F005796FC /* NSDictionary+MTLJSONKeyPath.h */; };
+		BE788B321E8F358300727A91 /* NSDictionary+MTLJSONKeyPath.h in Headers */ = {isa = PBXBuildFile; fileRef = 54EDCD0818D9B34F005796FC /* NSDictionary+MTLJSONKeyPath.h */; };
+		BE788B331E8F35B400727A91 /* NSDictionary+MTLJSONKeyPath.m in Sources */ = {isa = PBXBuildFile; fileRef = 54EDCD0918D9B34F005796FC /* NSDictionary+MTLJSONKeyPath.m */; };
+		BE788B341E8F35B600727A91 /* NSDictionary+MTLJSONKeyPath.m in Sources */ = {isa = PBXBuildFile; fileRef = 54EDCD0918D9B34F005796FC /* NSDictionary+MTLJSONKeyPath.m */; };
+		BE788B351E8F35B700727A91 /* NSDictionary+MTLJSONKeyPath.m in Sources */ = {isa = PBXBuildFile; fileRef = 54EDCD0918D9B34F005796FC /* NSDictionary+MTLJSONKeyPath.m */; };
+		BE788B361E8F35B800727A91 /* NSDictionary+MTLJSONKeyPath.m in Sources */ = {isa = PBXBuildFile; fileRef = 54EDCD0918D9B34F005796FC /* NSDictionary+MTLJSONKeyPath.m */; };
+		BE788B371E8F360B00727A91 /* MTLJSONKeyPath.m in Sources */ = {isa = PBXBuildFile; fileRef = BE298E491E8EF4F6003A9848 /* MTLJSONKeyPath.m */; };
+		BE788B381E8F361000727A91 /* MTLJSONKeyPath.m in Sources */ = {isa = PBXBuildFile; fileRef = BE298E491E8EF4F6003A9848 /* MTLJSONKeyPath.m */; };
+		BE788B391E8F361400727A91 /* MTLJSONKeyPath.m in Sources */ = {isa = PBXBuildFile; fileRef = BE298E491E8EF4F6003A9848 /* MTLJSONKeyPath.m */; };
+		BEC058161E8EF888006F5A1D /* MTLJSONKeyPath.h in Headers */ = {isa = PBXBuildFile; fileRef = BE298E481E8EF4F6003A9848 /* MTLJSONKeyPath.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BEC058171E8EF888006F5A1D /* MTLJSONKeyPath.h in Headers */ = {isa = PBXBuildFile; fileRef = BE298E481E8EF4F6003A9848 /* MTLJSONKeyPath.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BEC058181E8EF889006F5A1D /* MTLJSONKeyPath.h in Headers */ = {isa = PBXBuildFile; fileRef = BE298E481E8EF4F6003A9848 /* MTLJSONKeyPath.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CD7C6D8A1D33ACCC002EC294 /* NSError+MTLModelException.m in Sources */ = {isa = PBXBuildFile; fileRef = 54803A31178829A700011B39 /* NSError+MTLModelException.m */; };
 		CD7C6D8B1D33ACCC002EC294 /* NSValueTransformer+MTLPredefinedTransformerAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = D0F117481614C5600092520B /* NSValueTransformer+MTLPredefinedTransformerAdditions.m */; };
 		CD7C6D8C1D33ACCC002EC294 /* NSDictionary+MTLMappingAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 547F78541822BCFD00BBAB7B /* NSDictionary+MTLMappingAdditions.m */; };
 		CD7C6D8D1D33ACCC002EC294 /* MTLReflection.m in Sources */ = {isa = PBXBuildFile; fileRef = D058FE1E16EFB3D2009DFB47 /* MTLReflection.m */; };
-		CD7C6D8E1D33ACCC002EC294 /* NSDictionary+MTLJSONKeyPath.m in Sources */ = {isa = PBXBuildFile; fileRef = 54EDCD0918D9B34F005796FC /* NSDictionary+MTLJSONKeyPath.m */; };
 		CD7C6D8F1D33ACCC002EC294 /* MTLModel+NSCoding.m in Sources */ = {isa = PBXBuildFile; fileRef = D01BD0AE16CB52E800EC95C7 /* MTLModel+NSCoding.m */; };
 		CD7C6D901D33ACCC002EC294 /* NSObject+MTLComparisonAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 1ED5B5CF163A4E3C0072668E /* NSObject+MTLComparisonAdditions.m */; };
 		CD7C6D911D33ACCC002EC294 /* MTLModel.m in Sources */ = {isa = PBXBuildFile; fileRef = D0760E7715FFBF330060F550 /* MTLModel.m */; };
@@ -71,7 +86,6 @@
 		CDEEABAA1D33FC5100240A4B /* NSValueTransformer+MTLPredefinedTransformerAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = D0F117481614C5600092520B /* NSValueTransformer+MTLPredefinedTransformerAdditions.m */; };
 		CDEEABAB1D33FC5100240A4B /* NSDictionary+MTLMappingAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 547F78541822BCFD00BBAB7B /* NSDictionary+MTLMappingAdditions.m */; };
 		CDEEABAC1D33FC5100240A4B /* MTLReflection.m in Sources */ = {isa = PBXBuildFile; fileRef = D058FE1E16EFB3D2009DFB47 /* MTLReflection.m */; };
-		CDEEABAD1D33FC5100240A4B /* NSDictionary+MTLJSONKeyPath.m in Sources */ = {isa = PBXBuildFile; fileRef = 54EDCD0918D9B34F005796FC /* NSDictionary+MTLJSONKeyPath.m */; };
 		CDEEABAE1D33FC5100240A4B /* MTLModel+NSCoding.m in Sources */ = {isa = PBXBuildFile; fileRef = D01BD0AE16CB52E800EC95C7 /* MTLModel+NSCoding.m */; };
 		CDEEABAF1D33FC5100240A4B /* NSObject+MTLComparisonAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 1ED5B5CF163A4E3C0072668E /* NSObject+MTLComparisonAdditions.m */; };
 		CDEEABB01D33FC5100240A4B /* MTLModel.m in Sources */ = {isa = PBXBuildFile; fileRef = D0760E7715FFBF330060F550 /* MTLModel.m */; };
@@ -129,9 +143,7 @@
 		D05317741A168D3D00A5FBE2 /* MTLTransformerErrorHandling.h in Headers */ = {isa = PBXBuildFile; fileRef = 547165A31801977000E734DB /* MTLTransformerErrorHandling.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D05317751A168D3D00A5FBE2 /* MTLTransformerErrorHandling.m in Sources */ = {isa = PBXBuildFile; fileRef = 5487912318210717007F8347 /* MTLTransformerErrorHandling.m */; };
 		D05317761A168D6D00A5FBE2 /* NSDictionary+MTLMappingAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 547F78541822BCFD00BBAB7B /* NSDictionary+MTLMappingAdditions.m */; };
-		D05317771A168D6D00A5FBE2 /* NSDictionary+MTLJSONKeyPath.m in Sources */ = {isa = PBXBuildFile; fileRef = 54EDCD0918D9B34F005796FC /* NSDictionary+MTLJSONKeyPath.m */; };
 		D05317781A168D6D00A5FBE2 /* NSDictionary+MTLMappingAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 547F78541822BCFD00BBAB7B /* NSDictionary+MTLMappingAdditions.m */; };
-		D05317791A168D6D00A5FBE2 /* NSDictionary+MTLJSONKeyPath.m in Sources */ = {isa = PBXBuildFile; fileRef = 54EDCD0918D9B34F005796FC /* NSDictionary+MTLJSONKeyPath.m */; };
 		D053177A1A168D7100A5FBE2 /* NSDictionary+MTLMappingAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 547F78531822BCFD00BBAB7B /* NSDictionary+MTLMappingAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D053177B1A168D7200A5FBE2 /* NSDictionary+MTLMappingAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 547F78531822BCFD00BBAB7B /* NSDictionary+MTLMappingAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D053177E1A168F8B00A5FBE2 /* MTLTestJSONAdapter.m in Sources */ = {isa = PBXBuildFile; fileRef = D053177D1A168F8B00A5FBE2 /* MTLTestJSONAdapter.m */; };
@@ -301,6 +313,8 @@
 		88080C16160A706900CCABF2 /* NSArray+MTLManipulationAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSArray+MTLManipulationAdditions.h"; sourceTree = "<group>"; };
 		88080C17160A706900CCABF2 /* NSArray+MTLManipulationAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSArray+MTLManipulationAdditions.m"; sourceTree = "<group>"; };
 		88080C1C160A719D00CCABF2 /* MTLArrayManipulationSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MTLArrayManipulationSpec.m; sourceTree = "<group>"; };
+		BE298E481E8EF4F6003A9848 /* MTLJSONKeyPath.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MTLJSONKeyPath.h; sourceTree = "<group>"; };
+		BE298E491E8EF4F6003A9848 /* MTLJSONKeyPath.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MTLJSONKeyPath.m; sourceTree = "<group>"; };
 		CD7C6DB21D33ACCC002EC294 /* Mantle.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Mantle.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CDEEABD11D33FC5100240A4B /* Mantle.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Mantle.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CDEEABFA1D33FC7900240A4B /* Mantle-tvOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Mantle-tvOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -607,6 +621,8 @@
 				D0760E7715FFBF330060F550 /* MTLModel.m */,
 				D01BD0AD16CB52E800EC95C7 /* MTLModel+NSCoding.h */,
 				D01BD0AE16CB52E800EC95C7 /* MTLModel+NSCoding.m */,
+				BE298E481E8EF4F6003A9848 /* MTLJSONKeyPath.h */,
+				BE298E491E8EF4F6003A9848 /* MTLJSONKeyPath.m */,
 				D058FE1D16EFB3D2009DFB47 /* MTLReflection.h */,
 				D058FE1E16EFB3D2009DFB47 /* MTLReflection.m */,
 				D01BD0AB16CB46B600EC95C7 /* Adapters */,
@@ -667,7 +683,9 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BE788B321E8F358300727A91 /* NSDictionary+MTLJSONKeyPath.h in Headers */,
 				CD7C6D9C1D33ACCC002EC294 /* NSArray+MTLManipulationAdditions.h in Headers */,
+				BEC058181E8EF889006F5A1D /* MTLJSONKeyPath.h in Headers */,
 				CD7C6D9D1D33ACCC002EC294 /* MTLModel+NSCoding.h in Headers */,
 				54B45F4E23D4BD86007534E1 /* metamacros.h in Headers */,
 				54B45F5B23D4BDA0007534E1 /* EXTKeyPathCoding.h in Headers */,
@@ -690,7 +708,9 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BE788B311E8F358300727A91 /* NSDictionary+MTLJSONKeyPath.h in Headers */,
 				CDEEABBB1D33FC5100240A4B /* NSArray+MTLManipulationAdditions.h in Headers */,
+				BEC058171E8EF888006F5A1D /* MTLJSONKeyPath.h in Headers */,
 				CDEEABBC1D33FC5100240A4B /* MTLModel+NSCoding.h in Headers */,
 				54B45F4D23D4BD86007534E1 /* metamacros.h in Headers */,
 				54B45F5C23D4BDA1007534E1 /* EXTKeyPathCoding.h in Headers */,
@@ -713,7 +733,9 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BE788B2F1E8F358100727A91 /* NSDictionary+MTLJSONKeyPath.h in Headers */,
 				D0760E0515FFBD440060F550 /* Mantle.h in Headers */,
+				BE298E4A1E8EF4F6003A9848 /* MTLJSONKeyPath.h in Headers */,
 				D0760E7815FFBF330060F550 /* MTLModel.h in Headers */,
 				54B45F4B23D4BD85007534E1 /* metamacros.h in Headers */,
 				54B45F5E23D4BDA2007534E1 /* EXTKeyPathCoding.h in Headers */,
@@ -736,7 +758,9 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BE788B301E8F358200727A91 /* NSDictionary+MTLJSONKeyPath.h in Headers */,
 				D0E9C38319F6DC5B000D427D /* NSArray+MTLManipulationAdditions.h in Headers */,
+				BEC058161E8EF888006F5A1D /* MTLJSONKeyPath.h in Headers */,
 				D0E9C37919F6DC5B000D427D /* MTLModel+NSCoding.h in Headers */,
 				54B45F4C23D4BD85007534E1 /* metamacros.h in Headers */,
 				54B45F5D23D4BDA1007534E1 /* EXTKeyPathCoding.h in Headers */,
@@ -995,6 +1019,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				54B45F5223D4BD93007534E1 /* EXTScope.m in Sources */,
+				BE788B391E8F361400727A91 /* MTLJSONKeyPath.m in Sources */,
 				CD7C6D8A1D33ACCC002EC294 /* NSError+MTLModelException.m in Sources */,
 				CD7C6D8B1D33ACCC002EC294 /* NSValueTransformer+MTLPredefinedTransformerAdditions.m in Sources */,
 				CD7C6D8C1D33ACCC002EC294 /* NSDictionary+MTLMappingAdditions.m in Sources */,
@@ -1004,6 +1029,7 @@
 				CD7C6D8F1D33ACCC002EC294 /* MTLModel+NSCoding.m in Sources */,
 				CD7C6D901D33ACCC002EC294 /* NSObject+MTLComparisonAdditions.m in Sources */,
 				CD7C6D911D33ACCC002EC294 /* MTLModel.m in Sources */,
+				BE788B361E8F35B800727A91 /* NSDictionary+MTLJSONKeyPath.m in Sources */,
 				CD7C6D921D33ACCC002EC294 /* MTLJSONAdapter.m in Sources */,
 				CD7C6D931D33ACCC002EC294 /* NSArray+MTLManipulationAdditions.m in Sources */,
 				CD7C6D941D33ACCC002EC294 /* MTLTransformerErrorHandling.m in Sources */,
@@ -1018,6 +1044,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				54B45F5123D4BD92007534E1 /* EXTScope.m in Sources */,
+				BE788B381E8F361000727A91 /* MTLJSONKeyPath.m in Sources */,
 				CDEEABA91D33FC5100240A4B /* NSError+MTLModelException.m in Sources */,
 				CDEEABAA1D33FC5100240A4B /* NSValueTransformer+MTLPredefinedTransformerAdditions.m in Sources */,
 				CDEEABAB1D33FC5100240A4B /* NSDictionary+MTLMappingAdditions.m in Sources */,
@@ -1027,6 +1054,7 @@
 				CDEEABAE1D33FC5100240A4B /* MTLModel+NSCoding.m in Sources */,
 				CDEEABAF1D33FC5100240A4B /* NSObject+MTLComparisonAdditions.m in Sources */,
 				CDEEABB01D33FC5100240A4B /* MTLModel.m in Sources */,
+				BE788B351E8F35B700727A91 /* NSDictionary+MTLJSONKeyPath.m in Sources */,
 				CDEEABB11D33FC5100240A4B /* MTLJSONAdapter.m in Sources */,
 				CDEEABB21D33FC5100240A4B /* NSArray+MTLManipulationAdditions.m in Sources */,
 				CDEEABB31D33FC5100240A4B /* MTLTransformerErrorHandling.m in Sources */,
@@ -1064,15 +1092,16 @@
 			buildActionMask = 2147483647;
 			files = (
 				54B45F4F23D4BD91007534E1 /* EXTScope.m in Sources */,
+				BE298E4B1E8EF4F6003A9848 /* MTLJSONKeyPath.m in Sources */,
 				D0760E7915FFBF330060F550 /* MTLModel.m in Sources */,
 				D08B5AAF16002694001FE685 /* MTLValueTransformer.m in Sources */,
 				88080C19160A706900CCABF2 /* NSArray+MTLManipulationAdditions.m in Sources */,
 				D0C27D0B16110973002FE587 /* NSDictionary+MTLManipulationAdditions.m in Sources */,
 				D0F1174A1614C5600092520B /* NSValueTransformer+MTLPredefinedTransformerAdditions.m in Sources */,
 				54B45F5623D4BD96007534E1 /* EXTRuntimeExtensions.m in Sources */,
+				BE788B331E8F35B400727A91 /* NSDictionary+MTLJSONKeyPath.m in Sources */,
 				D05317731A168D3D00A5FBE2 /* MTLTransformerErrorHandling.m in Sources */,
 				1ED5B5D1163A4E3C0072668E /* NSObject+MTLComparisonAdditions.m in Sources */,
-				D05317771A168D6D00A5FBE2 /* NSDictionary+MTLJSONKeyPath.m in Sources */,
 				D01BD09F16CB432D00EC95C7 /* MTLJSONAdapter.m in Sources */,
 				54803A34178829A800011B39 /* NSError+MTLModelException.m in Sources */,
 				D01BD0B116CB52E800EC95C7 /* MTLModel+NSCoding.m in Sources */,
@@ -1110,6 +1139,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				54B45F5023D4BD92007534E1 /* EXTScope.m in Sources */,
+				BE788B371E8F360B00727A91 /* MTLJSONKeyPath.m in Sources */,
 				D0E9C38619F6DC5B000D427D /* NSError+MTLModelException.m in Sources */,
 				D0E9C38E19F6DC5B000D427D /* NSValueTransformer+MTLPredefinedTransformerAdditions.m in Sources */,
 				D05317781A168D6D00A5FBE2 /* NSDictionary+MTLMappingAdditions.m in Sources */,
@@ -1119,6 +1149,7 @@
 				D0E9C37A19F6DC5B000D427D /* MTLModel+NSCoding.m in Sources */,
 				D0E9C38A19F6DC5B000D427D /* NSObject+MTLComparisonAdditions.m in Sources */,
 				D0E9C37819F6DC5B000D427D /* MTLModel.m in Sources */,
+				BE788B341E8F35B600727A91 /* NSDictionary+MTLJSONKeyPath.m in Sources */,
 				D0E9C37E19F6DC5B000D427D /* MTLJSONAdapter.m in Sources */,
 				D0E9C38419F6DC5B000D427D /* NSArray+MTLManipulationAdditions.m in Sources */,
 				D05317751A168D3D00A5FBE2 /* MTLTransformerErrorHandling.m in Sources */,

--- a/Mantle/MTLJSONAdapter.h
+++ b/Mantle/MTLJSONAdapter.h
@@ -33,13 +33,15 @@
 ///         return @{
 ///             @"name": @"POI.name",
 ///             @"point": @[ @"latitude", @"longitude" ],
-///             @"starred": @"starred"
+///             @"starred": @"starred",
+///             @"username": MTLKeyPath(@"com.github", @"user", @"username")
 ///         };
 ///     }
 ///
 /// This will map the `starred` property to `JSONDictionary[@"starred"]`, `name`
-/// to `JSONDictionary[@"POI"][@"name"]` and `point` to a dictionary equivalent
-/// to:
+/// to `JSONDictionary[@"POI"][@"name"]`, `username` to
+/// `JSONDictionary[@"com.github"][@"user"][@"username"]`, and `point` to a
+/// dictionary equivalent to:
 ///
 ///     @{
 ///         @"latitude": JSONDictionary[@"latitude"],
@@ -47,7 +49,7 @@
 ///     }
 ///
 /// Returns a dictionary mapping property keys to one or multiple JSON key paths
-/// (as strings or arrays of strings).
+/// (as NSStrings, MTLJSONKeyPaths, or NSArrays of NSStrings or MTLJSONKeyPaths).
 + (NSDictionary *)JSONKeyPathsByPropertyKey;
 
 @optional

--- a/Mantle/MTLJSONAdapter.m
+++ b/Mantle/MTLJSONAdapter.m
@@ -13,6 +13,7 @@
 #import <Mantle/EXTRuntimeExtensions.h>
 #import <Mantle/EXTScope.h>
 #import "MTLJSONAdapter.h"
+#import "MTLJSONKeyPath.h"
 #import "MTLModel.h"
 #import "MTLTransformerErrorHandling.h"
 #import "MTLReflection.h"
@@ -155,11 +156,12 @@ NSString * const MTLJSONAdapterThrownExceptionErrorKey = @"MTLJSONAdapterThrownE
 		if ([value isKindOfClass:NSArray.class]) {
 			for (NSString *keyPath in value) {
 				if ([keyPath isKindOfClass:NSString.class]) continue;
+				if ([keyPath isKindOfClass:MTLJSONKeyPath.class]) continue;
 
 				NSAssert(NO, @"%@ must either map to a JSON key path or a JSON array of key paths, got: %@.", mappedPropertyKey, value);
 				return nil;
 			}
-		} else if (![value isKindOfClass:NSString.class]) {
+		} else if (![value isKindOfClass:NSString.class] && ![value isKindOfClass:MTLJSONKeyPath.class]) {
 			NSAssert(NO, @"%@ must either map to a JSON key path or a JSON array of key paths, got: %@.",mappedPropertyKey, value);
 			return nil;
 		}
@@ -217,34 +219,40 @@ NSString * const MTLJSONAdapterThrownExceptionErrorKey = @"MTLJSONAdapterThrownE
 			}
 		}
 
-		void (^createComponents)(id, NSString *) = ^(id obj, NSString *keyPath) {
-			NSArray *keyPathComponents = [keyPath componentsSeparatedByString:@"."];
-
-			// Set up dictionaries at each step of the key path.
-			for (NSString *component in keyPathComponents) {
-				if ([obj valueForKey:component] == nil) {
-					// Insert an empty mutable dictionary at this spot so that we
-					// can set the whole key path afterward.
-					[obj setValue:[NSMutableDictionary dictionary] forKey:component];
-				}
-
-				obj = [obj valueForKey:component];
+		void (^createComponentsAndSetValue)(id, id, id) = ^(NSMutableDictionary *dictionary, id keyPath, id value) {
+			NSArray *keyPathComponents;
+			if ([keyPath isKindOfClass:MTLJSONKeyPath.class]) {
+				keyPathComponents = ((MTLJSONKeyPath *)keyPath).components;
+			} else {
+				keyPathComponents = [(NSString *)keyPath componentsSeparatedByString:@"."];
 			}
+			
+			// Set up dictionaries at each step of the key path
+			__block NSMutableDictionary *currentDictionary = dictionary;
+			NSUInteger componentCount = keyPathComponents.count;
+			[keyPathComponents enumerateObjectsUsingBlock:^(NSString *component, NSUInteger idx, BOOL *stop) {
+				if (idx < componentCount - 1) {
+					if ([currentDictionary valueForKey:component] == nil) {
+						// Insert an empty mutable dictionary at this spot so
+						// that we can set the value at the end.
+						[currentDictionary setValue:[NSMutableDictionary dictionary] forKey:component];
+					}
+					currentDictionary = [currentDictionary valueForKey:component];
+				} else {
+					// Set the actual value at the last key
+					[currentDictionary setValue:value forKey:component];
+				}
+			}];
 		};
 
-		if ([JSONKeyPaths isKindOfClass:NSString.class]) {
-			createComponents(JSONDictionary, JSONKeyPaths);
-
-			[JSONDictionary setValue:value forKeyPath:JSONKeyPaths];
-		}
-
 		if ([JSONKeyPaths isKindOfClass:NSArray.class]) {
-			for (NSString *JSONKeyPath in JSONKeyPaths) {
-				createComponents(JSONDictionary, JSONKeyPath);
-
-				[JSONDictionary setValue:value[JSONKeyPath] forKeyPath:JSONKeyPath];
+			for (id JSONKeyPath in JSONKeyPaths) {
+				createComponentsAndSetValue(JSONDictionary, JSONKeyPath, value[JSONKeyPath]);
 			}
+		} else {
+			createComponentsAndSetValue(JSONDictionary, JSONKeyPaths, value);
 		}
+		
 	}];
 
 	if (success) {
@@ -304,7 +312,7 @@ NSString * const MTLJSONAdapterThrownExceptionErrorKey = @"MTLJSONAdapterThrownE
 		if ([JSONKeyPaths isKindOfClass:NSArray.class]) {
 			NSMutableDictionary *dictionary = [NSMutableDictionary dictionary];
 
-			for (NSString *keyPath in JSONKeyPaths) {
+			for (id keyPath in JSONKeyPaths) {
 				BOOL success = NO;
 				id value = [JSONDictionary mtl_valueForJSONKeyPath:keyPath success:&success error:error];
 

--- a/Mantle/MTLJSONAdapter.m
+++ b/Mantle/MTLJSONAdapter.m
@@ -219,7 +219,7 @@ NSString * const MTLJSONAdapterThrownExceptionErrorKey = @"MTLJSONAdapterThrownE
 			}
 		}
 
-		void (^createComponentsAndSetValue)(id, id, id) = ^(NSMutableDictionary *dictionary, id keyPath, id value) {
+		void (^createComponentsAndSetValue)(NSMutableDictionary *, id, id) = ^(NSMutableDictionary *dictionary, id keyPath, id value) {
 			NSArray *keyPathComponents;
 			if ([keyPath isKindOfClass:MTLJSONKeyPath.class]) {
 				keyPathComponents = ((MTLJSONKeyPath *)keyPath).components;

--- a/Mantle/MTLJSONKeyPath.h
+++ b/Mantle/MTLJSONKeyPath.h
@@ -1,0 +1,36 @@
+//
+//  MTLJSONKeyPath.h
+//  Mantle
+//
+//  Created by Will Lisac on 3/31/17.
+//  Copyright © 2017 GitHub. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// A class used to represent a JSON key path by discrete key components.
+@interface MTLJSONKeyPath : NSObject <NSCopying>
+
+/// An array of JSON keys that represent a JSON key path.
+///
+/// This property will never be nil.
+@property (nonatomic, strong, readonly) NSArray<NSString *> *components;
+
+/// Initializes the receiver with the given JSON key components.
+///
+/// components - The array of JSON keys that represent a JSON key path.
+///              This argument must not be nil.
+///
+/// Returns an initialized JSON Key path.
+- (instancetype)initWithComponents:(NSArray<NSString *> *)components;
+
+@end
+
+/// MTLKeyPath is a macro that initializes and returns a MTLJSONKeyPath
+/// object with the given JSON key components.
+#define MTLKeyPath(...) \
+	[[MTLJSONKeyPath alloc] initWithComponents:@[__VA_ARGS__]]
+
+NS_ASSUME_NONNULL_END

--- a/Mantle/MTLJSONKeyPath.m
+++ b/Mantle/MTLJSONKeyPath.m
@@ -1,0 +1,53 @@
+//
+//  MTLJSONKeyPath.m
+//  Mantle
+//
+//  Created by Will Lisac on 3/31/17.
+//  Copyright © 2017 GitHub. All rights reserved.
+//
+
+#import "MTLJSONKeyPath.h"
+
+@interface MTLJSONKeyPath ()
+
+@property (nonatomic, strong, readwrite) NSArray *components;
+
+@end
+
+@implementation MTLJSONKeyPath
+
+- (instancetype)initWithComponents:(NSArray<NSString *> *)components {
+	self = [super init];
+	if (self == nil) return nil;
+	
+	self.components = components;
+	
+	return self;
+}
+
+#pragma mark NSCopying
+
+- (instancetype)copyWithZone:(NSZone *)zone {
+	MTLJSONKeyPath *copy = [[self.class allocWithZone:zone] init];
+	copy.components = [self.components copy];
+	return copy;
+}
+
+#pragma mark NSObject
+
+- (NSString *)description {
+	return [NSString stringWithFormat:@"<%@: %p> %@", self.class, self, self.components];
+}
+
+- (NSUInteger)hash {
+	return [self.components hash];
+}
+
+- (BOOL)isEqual:(MTLJSONKeyPath *)object {
+	if (self == object) return YES;
+	if (![object isMemberOfClass:self.class]) return NO;
+	
+	return [self.components isEqualToArray:object.components];
+}
+
+@end

--- a/Mantle/Mantle.h
+++ b/Mantle/Mantle.h
@@ -15,6 +15,7 @@ FOUNDATION_EXPORT double MantleVersionNumber;
 FOUNDATION_EXPORT const unsigned char MantleVersionString[];
 
 #import <Mantle/MTLJSONAdapter.h>
+#import <Mantle/MTLJSONKeyPath.h>
 #import <Mantle/MTLModel.h>
 #import <Mantle/MTLModel+NSCoding.h>
 #import <Mantle/MTLValueTransformer.h>

--- a/Mantle/NSDictionary+MTLJSONKeyPath.h
+++ b/Mantle/NSDictionary+MTLJSONKeyPath.h
@@ -12,8 +12,9 @@
 
 /// Looks up the value of a key path in the receiver.
 ///
-/// JSONKeyPath - The key path that should be resolved. Every element along this
-///               key path needs to be an instance of NSDictionary for the
+/// JSONKeyPath - The key path that should be resolved. The key path must be
+///               an instance of NSString or MTLJSONKeyPath. Every element along
+///               this key path needs to be an instance of NSDictionary for the
 ///               resolving to be successful.
 /// success     - If not NULL, this will be set to a boolean indicating whether
 ///               the key path was resolved successfully.
@@ -22,6 +23,6 @@
 ///
 /// Returns the value for the key path which may be nil. Clients should inspect
 /// the success parameter to decide how to proceed with the result.
-- (id)mtl_valueForJSONKeyPath:(NSString *)JSONKeyPath success:(BOOL *)success error:(NSError **)error;
+- (id)mtl_valueForJSONKeyPath:(id)JSONKeyPath success:(BOOL *)success error:(NSError **)error;
 
 @end

--- a/Mantle/NSDictionary+MTLJSONKeyPath.m
+++ b/Mantle/NSDictionary+MTLJSONKeyPath.m
@@ -9,11 +9,18 @@
 #import "NSDictionary+MTLJSONKeyPath.h"
 
 #import "MTLJSONAdapter.h"
+#import "MTLJSONKeyPath.h"
 
 @implementation NSDictionary (MTLJSONKeyPath)
 
-- (id)mtl_valueForJSONKeyPath:(NSString *)JSONKeyPath success:(BOOL *)success error:(NSError **)error {
-	NSArray *components = [JSONKeyPath componentsSeparatedByString:@"."];
+- (id)mtl_valueForJSONKeyPath:(id)JSONKeyPath success:(BOOL *)success error:(NSError **)error {
+	NSArray *components;
+	
+	if ([JSONKeyPath isKindOfClass:[MTLJSONKeyPath class]]) {
+		components = ((MTLJSONKeyPath *)JSONKeyPath).components;
+	} else {
+		components = [(NSString *)JSONKeyPath componentsSeparatedByString:@"."];
+	}
 
 	id result = self;
 	for (NSString *component in components) {

--- a/MantleTests/MTLJSONAdapterSpec.m
+++ b/MantleTests/MTLJSONAdapterSpec.m
@@ -106,6 +106,34 @@ it(@"it should initialize properties with multiple key paths from JSON", ^{
 	expect(serializationError).to(beNil());
 });
 
+it(@"it should initialize properties with keys that contain dot literals from JSON", ^{
+	NSDictionary *values = @{
+							 @"literal.name": @"foo",
+							 @"literal.first_name": @"bar",
+							 @"literal.last_name": @"baz",
+							 @"nested": @{
+									 @"literal.name": @"qux",
+									 @"literal.first_name": @"grault",
+									 @"literal.last_name": @"xyzzy"
+									 }
+							 };
+	
+	NSError *error = nil;
+	MTLDotLiteralKeyPathModel *model = [MTLJSONAdapter modelOfClass:MTLDotLiteralKeyPathModel.class fromJSONDictionary:values error:&error];
+	expect(model).notTo(beNil());
+	expect(error).to(beNil());
+	
+	expect(model.name).to(equal(@"foo"));
+	expect(model.nestedName).to(equal(@"qux"));
+	
+	expect(model.fullName).to(equal(@"bar baz"));
+	expect(model.nestedFullName).to(equal(@"grault xyzzy"));
+	
+	__block NSError *serializationError;
+	expect([MTLJSONAdapter JSONDictionaryFromModel:model error:&serializationError]).to(equal(values));
+	expect(serializationError).to(beNil());
+});
+
 it(@"should return nil and error with an invalid key path from JSON",^{
 	NSDictionary *values = @{
 		@"username": @"foo",

--- a/MantleTests/MTLTestModel.h
+++ b/MantleTests/MTLTestModel.h
@@ -170,6 +170,25 @@ extern const NSInteger MTLTestModelNameMissing;
 
 @end
 
+@interface MTLDotLiteralKeyPathModel : MTLModel <MTLJSONSerializing>
+
+// This property is associated with the "literal.name" key in JSON.
+@property (readonly, nonatomic, assign) NSString *name;
+
+// This property is associated with the "'nested'.'literal.name'" key path
+// in JSON.
+@property (readonly, nonatomic, assign) NSString *nestedName;
+
+// This property is associated with the "literal.first_name" and
+// "literal.last_name" keys in JSON.
+@property (readonly, nonatomic, assign) NSString *fullName;
+
+// This property is associated with the "'nested'.'literal.first_name'" and
+// "'nested'.'literal.last_name'" key paths in JSON.
+@property (readonly, nonatomic, assign) NSString *nestedFullName;
+
+@end
+
 @interface MTLClassClusterModel : MTLModel <MTLJSONSerializing>
 
 @property (readonly, nonatomic, copy) NSString *flavor;

--- a/MantleTests/MTLTestModel.m
+++ b/MantleTests/MTLTestModel.m
@@ -10,6 +10,7 @@
 
 #import "MTLTestModel.h"
 #import "NSDictionary+MTLMappingAdditions.h"
+#import "MTLJSONKeyPath.h"
 
 NSString * const MTLTestModelErrorDomain = @"MTLTestModelErrorDomain";
 const NSInteger MTLTestModelNameTooLong = 1;
@@ -459,6 +460,49 @@ static NSUInteger modelVersion = 1;
 			};
 		}];
 }
+@end
+
+@implementation MTLDotLiteralKeyPathModel
+
++ (NSDictionary *)JSONKeyPathsByPropertyKey {
+	return @{
+			 @"name": MTLKeyPath(@"literal.name"),
+			 @"nestedName": MTLKeyPath(@"nested", @"literal.name"),
+			 @"fullName": @[ MTLKeyPath(@"literal.first_name"), MTLKeyPath(@"literal.last_name") ],
+			 @"nestedFullName": @[ MTLKeyPath(@"nested", @"literal.first_name"), MTLKeyPath(@"nested", @"literal.last_name") ]
+			 };
+}
+
++ (NSValueTransformer *)fullNameJSONTransformer {
+	return [MTLValueTransformer transformerUsingForwardBlock:^id(id value, BOOL *success, NSError *__autoreleasing *error) {
+		NSString *firstName = value[MTLKeyPath(@"literal.first_name")];
+		NSString *lastName = value[MTLKeyPath(@"literal.last_name")];
+		return [@[firstName, lastName] componentsJoinedByString:@" "];
+	} reverseBlock:^(NSString *value, BOOL *success, NSError **error) {
+		NSArray *nameComponents = [value componentsSeparatedByString:@" "];
+		
+		return @{
+				 MTLKeyPath(@"literal.first_name"): nameComponents[0],
+				 MTLKeyPath(@"literal.last_name"): nameComponents[1]
+				 };
+	}];
+}
+
++ (NSValueTransformer *)nestedFullNameJSONTransformer {
+	return [MTLValueTransformer transformerUsingForwardBlock:^id(id value, BOOL *success, NSError *__autoreleasing *error) {
+		NSString *firstName = value[MTLKeyPath(@"nested", @"literal.first_name")];
+		NSString *lastName = value[MTLKeyPath(@"nested", @"literal.last_name")];
+		return [@[firstName, lastName] componentsJoinedByString:@" "];
+	} reverseBlock:^(NSString *value, BOOL *success, NSError **error) {
+		NSArray *nameComponents = [value componentsSeparatedByString:@" "];
+		
+		return @{
+				 MTLKeyPath(@"nested", @"literal.first_name"): nameComponents[0],
+				 MTLKeyPath(@"nested", @"literal.last_name"): nameComponents[1]
+				 };
+	}];
+}
+
 @end
 
 @implementation MTLClassClusterModel : MTLModel


### PR DESCRIPTION
This is a rebase of @wlisac #790 to add support for dot literals in JSON key paths.  Original rationale can be found here: https://github.com/Mantle/Mantle/pull/790#issue-113800507