### PR TITLE
Fix build error w/ Xcode 12 with casting NSInteger

### DIFF
--- a/Mantle/NSValueTransformer+MTLPredefinedTransformerAdditions.m
+++ b/Mantle/NSValueTransformer+MTLPredefinedTransformerAdditions.m
@@ -195,7 +195,7 @@ NSString * const MTLBooleanValueTransformerName = @"MTLBooleanValueTransformerNa
 					if (error != NULL) {
 						NSDictionary *userInfo = @{
 							NSLocalizedDescriptionKey: NSLocalizedString(@"Could not transform array", @""),
-							NSLocalizedFailureReasonErrorKey: [NSString stringWithFormat:NSLocalizedString(@"Could not transform value at index %d", @""), index],
+							NSLocalizedFailureReasonErrorKey: [NSString stringWithFormat:NSLocalizedString(@"Could not transform value at index %ld", @""), (long)index],
 							NSUnderlyingErrorKey: underlyingError,
 							MTLTransformerErrorHandlingInputValueErrorKey: values
 						};
@@ -254,7 +254,7 @@ NSString * const MTLBooleanValueTransformerName = @"MTLBooleanValueTransformerNa
 						if (error != NULL) {
 							NSDictionary *userInfo = @{
 								NSLocalizedDescriptionKey: NSLocalizedString(@"Could not transform array", @""),
-								NSLocalizedFailureReasonErrorKey: [NSString stringWithFormat:NSLocalizedString(@"Could not transform value at index %d", @""), index],
+								NSLocalizedFailureReasonErrorKey: [NSString stringWithFormat:NSLocalizedString(@"Could not transform value at index %ld", @""), (long)index],
 								NSUnderlyingErrorKey: underlyingError,
 								MTLTransformerErrorHandlingInputValueErrorKey: values
 							};


### PR DESCRIPTION
Error
```
Values of type 'NSInteger' should not be used as format arguments; add an explicit cast to 'long' instead
```
Fix-it
```
Replace '%d", @""), ' with '%ld", @""), (long)'
```