### PR TITLE
Fix stringFromTypedBytes to properly typecast in * case

### DIFF
--- a/Mantle/extobjc/MTLEXTRuntimeExtensions.m
+++ b/Mantle/extobjc/MTLEXTRuntimeExtensions.m
@@ -915,7 +915,7 @@ NSString *mtl_stringFromTypedBytes (const void *bytes, const char *encoding) {
         case 'd': return @(*(double *)bytes).description;
         case 'B': return @(*(_Bool *)bytes).description;
         case 'v': return @"(void)";
-        case '*': return [NSString stringWithFormat:@"\"%s\"", bytes];
+        case '*': return [NSString stringWithFormat:@"\"%s\"", (char *)bytes];
 
         case '@':
         case '#': {


### PR DESCRIPTION
This was necessary to compile with Xcode 12.5. I'm admittedly a little unsure on the implications of this.