### PR TITLE
Bump minimum iOS version to `iOS 9`

### DIFF
--- a/Mantle.podspec.json
+++ b/Mantle.podspec.json
@@ -12,7 +12,7 @@
     "git": "https://github.com/Mantle/Mantle.git"
   },
   "platforms": {
-    "ios": "8.0",
+    "ios": "9.0",
     "osx": "10.10",
     "watchos": "2.0",
     "tvos": "9.0"

--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ let package = Package(
     name: "Mantle",
     platforms: [
         .macOS(.v10_10),
-        .iOS(.v8),
+        .iOS(.v9),
         .tvOS(.v9),
         .watchOS(.v2)
     ],


### PR DESCRIPTION
- This is done in order to get rid of the warning: 'The iOS Simulator deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 8.0, but the range of supported deployment target versions is 9.0 to 14.5.99.'
- This change should be safe since Apple requires us to use Xcode 12 to deploy apps to the AppStore (see https://developer.apple.com/news/?id=ib31uj1j) and Xcode 12 has the minimum deployment target of `iOS 9.0`