### PR TITLE
Fix for parsing URLs containing characters that need to be escaped

### DIFF
--- a/Mantle/NSValueTransformer+MTLPredefinedTransformerAdditions.m
+++ b/Mantle/NSValueTransformer+MTLPredefinedTransformerAdditions.m
@@ -39,6 +39,7 @@ NSString * const MTLBooleanValueTransformerName = @"MTLBooleanValueTransformerNa
 					return nil;
 				}
 
+                str = [str stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
 				NSURL *result = [NSURL URLWithString:str];
 
 				if (result == nil) {


### PR DESCRIPTION
We encountered an error while parsing json containing an URL value that contained characters like %2B, { and } in the query part. 
This could not be converted to an NSURL.

Parsing succeeds when using stringByAddingPercentEscapesUsingEncoding on the input string as advised by Apple.